### PR TITLE
Add new option to create a header with foward declaration of all functions

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -130,6 +130,9 @@ void ArgvParser::Print_Usage_Message(void)
 "  -DCE_SYMVERS_PATH=<arg>  Path to kernel Modules.symvers file.  Only used when\n"
 "                           -D__KERNEL__ is specified.\n"
 "  -DCE_DSC_OUTPUT=<arg>    Libpulp .dsc file output, used for userspace livepatching.\n"
+"  -DCE_OUTPUT_FUNCTION_PROTOTYPE_HEADER=<arg>\n"
+"                           Outputs a header file with a foward declaration of all\n"
+"                           functions. This header is not self-compilable.\n"
 "\n";
 
   llvm::outs() << "The following arguments are ignored by clang-extract:\n";
@@ -212,6 +215,11 @@ bool ArgvParser::Handle_Clang_Extract_Arg(const char *str)
   }
   if (prefix("-DCE_DSC_OUTPUT=", str)) {
     DescOutputPath = Extract_Single_Arg_C(str);
+
+    return true;
+  }
+  if (prefix("-DCE_OUTPUT_FUNCTION_PROTOTYPE_HEADER=", str)) {
+    OutputFunctionPrototypeHeader = Extract_Single_Arg_C(str);
 
     return true;
   }

--- a/libcextract/ArgvParser.hh
+++ b/libcextract/ArgvParser.hh
@@ -114,6 +114,11 @@ class ArgvParser
     return IncExpansionPolicy;
   }
 
+  inline const char *Get_Output_Path_To_Prototype_Header(void)
+  {
+    return OutputFunctionPrototypeHeader;
+  }
+
   const char *Get_Input_File(void);
 
   /** Print help usage message.  */
@@ -143,4 +148,6 @@ class ArgvParser
   const char *DescOutputPath;
 
   const char *IncExpansionPolicy;
+
+  const char *OutputFunctionPrototypeHeader;
 };

--- a/libcextract/FunctionDepsFinder.hh
+++ b/libcextract/FunctionDepsFinder.hh
@@ -37,6 +37,12 @@ class ClosureSet
   /** Mark decl as dependencies and all its previous decls versions.  */
   bool Add_Decl_And_Prevs(Decl *decl);
 
+  /** Add a single decl to the set.  */
+  void Add_Single_Decl(Decl *decl)
+  {
+    Dependencies.insert(decl);
+  }
+
   inline std::unordered_set<Decl *> &Get_Set(void)
   {
     return Dependencies;

--- a/libcextract/HeaderGenerate.cpp
+++ b/libcextract/HeaderGenerate.cpp
@@ -1,0 +1,75 @@
+//===- HeaderGenerate.hh - Output a header file for generated output. *- C++ -*-===//
+//
+// This project is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Remove the body of all functions and only outputs the foward declaration.
+//
+//===----------------------------------------------------------------------===//
+
+/* Author: Giuliano Belinassi  */
+
+#include "HeaderGenerate.hh"
+#include "FunctionDepsFinder.hh"
+#include "IncludeTree.hh"
+#include "PrettyPrint.hh"
+
+HeaderGeneration::HeaderGeneration(PassManager::Context *ctx)
+  : AST(ctx->AST.get())
+{
+  Run_Analysis(ctx->NamesLog);
+}
+
+void HeaderGeneration::Print(void)
+{
+  IncludeTree IT(AST); // Not necessary, just to use the RecursivePrint class.
+  RecursivePrint(AST, Closure.Get_Set(), IT, false).Print();
+}
+
+static bool Contains(const std::vector<ExternalizerLogEntry> &v, const std::string &name)
+{
+  for (const ExternalizerLogEntry &x : v) {
+    if ((x.Type == ExternalizationType::RENAME || x.Type == ExternalizationType::WEAK)
+        && x.NewName == name) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool HeaderGeneration::Run_Analysis(const std::vector<ExternalizerLogEntry> &set)
+{
+  ASTUnit::top_level_iterator it;
+  for (it = AST->top_level_begin(); it != AST->top_level_end(); ++it) {
+    Decl *decl = *it;
+
+    if (FunctionDecl *fdecl = dyn_cast<FunctionDecl>(decl)) {
+      if (Contains(set, fdecl->getNameAsString())) {
+        if (fdecl->doesThisDeclarationHaveABody() && fdecl->hasBody()) {
+          Stmt *body = fdecl->getBody();
+          fdecl->setRangeEnd(body->getBeginLoc().getLocWithOffset(-1));
+          fdecl->setBody(nullptr);
+        }
+        Closure.Add_Single_Decl(fdecl);
+      }
+    }
+  }
+
+  /* Do not output any macros.  */
+  MacroWalker mw(AST->getPreprocessor());
+  PreprocessingRecord *rec = AST->getPreprocessor().getPreprocessingRecord();
+  for (PreprocessedEntity *entity : *rec) {
+    if (MacroDefinitionRecord *def = dyn_cast<MacroDefinitionRecord>(entity)) {
+      if (MacroInfo *info = mw.Get_Macro_Info(def)) {
+        info->setIsUsed(false);
+      }
+    }
+  }
+
+  return true;
+}

--- a/libcextract/HeaderGenerate.hh
+++ b/libcextract/HeaderGenerate.hh
@@ -1,0 +1,42 @@
+//===- HeaderGenerate.hh - Output a header file for generated output. *- C++ -*-===//
+//
+// This project is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Remove the body of all functions and only outputs the foward declaration.
+//
+//===----------------------------------------------------------------------===//
+
+/* Author: Giuliano Belinassi  */
+
+#pragma once
+
+#include "Passes.hh"
+#include "FunctionDepsFinder.hh"
+#include "SymbolExternalizer.hh"
+
+
+using namespace clang;
+
+/** Outputs a header file with a foward declarations of all functions in the current
+ *  AST.
+ *
+ *  WARNING:  This class modifies the AST.
+ */
+class HeaderGeneration
+{
+  public:
+  HeaderGeneration(PassManager::Context *);
+
+  bool Run_Analysis(const std::vector<ExternalizerLogEntry> &set);
+
+  void Print(void);
+
+  protected:
+  ASTUnit *AST;
+  ClosureSet Closure;
+};

--- a/libcextract/Passes.hh
+++ b/libcextract/Passes.hh
@@ -59,6 +59,7 @@ class PassManager {
             IpaclonesPath(args.Get_Ipaclones_Path()),
             SymversPath(args.Get_Symvers_Path()),
             DscOutputPath(args.Get_Dsc_Output_Path()),
+            OutputFunctionPrototypeHeader(args.Get_Output_Path_To_Prototype_Header()),
             IncExpansionPolicy(IncludeExpansionPolicy::Get_Overriding(
                                args.Get_Include_Expansion_Policy(), Kernel)),
             NamesLog(),
@@ -118,6 +119,9 @@ class PassManager {
 
         /* Path to libpulp .dsc file for output.  */
         const char *DscOutputPath;
+
+        /* Output path to a file containing foward declarations of all functions.  */
+        const char *OutputFunctionPrototypeHeader;
 
         /* Policy used to expand includes.  */
         IncludeExpansionPolicy::Policy IncExpansionPolicy;

--- a/libcextract/meson.build
+++ b/libcextract/meson.build
@@ -32,7 +32,8 @@ libcextract_sources = [
   'SymbolExternalizer.cpp',
   'SymversParser.cpp',
   'TopLevelASTIterator.cpp',
-  'ExpansionPolicy.cpp'
+  'ExpansionPolicy.cpp',
+  'HeaderGenerate.cpp'
 ]
 
 libcextract_static = static_library('cextract', libcextract_sources)


### PR DESCRIPTION
This commit adds a way for clang-extract to generate a header file containing forward declarations of all functions.

This can be enabled by using -DCE_OUTPUT_FUNCTION_PROTOTYPE_HEADER=<arg>. The generated file is not self-compilable.

@marcosps Please review and check if this is the intended behavior.