### PR TITLE
Fix redeclaration of RecordDecl in Records defined in array variables

### DIFF
--- a/testsuite/small/record-4.c
+++ b/testsuite/small/record-4.c
@@ -1,0 +1,18 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+static const struct mount_opts
+{
+  int token;
+  int mount_opts;
+  int flags;
+} ext4_mount_opts[] = {
+  {1, 1, 1}
+};
+
+int f(void)
+{
+  return ext4_mount_opts[0].token;
+}
+
+/* { dg-final { scan-tree-dump "static const struct mount_opts\n{\n *int token;\n *int mount_opts;\n *int flags;\n} ext4_mount_opts\[\] = {\n *{1, 1, 1}\n};" } } */
+/* { dg-final { scan-tree-dump "return ext4_mount_opts\[0\]\.token;" } } */


### PR DESCRIPTION
There are some cases where a variable is declared as follows:
```
  static const struct mount_opts
  {
    int token;
    int mount_opts;
    int flags;
  } ext4_mount_opts[] = {
    {1, 1, 1}
  };
```
in this case, the `ext4_mount_opts` array is declared together with its type, thus resulting in Clang splitting this into two decls in its AST:
```
  struct mount_opts
  {
    int token;
    int mount_opts;
    int flags;
  };

  static const struct ext4_mount_opts[] = {
    {1, 1, 1}
  };
```
but since we try to get what the user wrote, it results in two declarations of `struct mount_opts`, thus clang-extract fails because of a redeclaration error. But since `ext4_mount_opts` is an array, geting its type returns an array type, not the struct declaration itself, hence check for this case as well.