### PR TITLE
Fix `Update_References_To_Symbol` skipping variable initializer

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -436,7 +436,12 @@ bool SymbolExternalizer::FunctionUpdater::Update_References_To_Symbol(Declarator
 {
   ToUpdate = to_update;
   if (to_update) {
-    return Update_References_To_Symbol(to_update->getBody());
+    if (VarDecl *vdecl = dyn_cast<VarDecl>(to_update)) {
+      return Update_References_To_Symbol(vdecl->getInit());
+    }
+    if (FunctionDecl *fdecl = dyn_cast<FunctionDecl>(to_update)) {
+      return Update_References_To_Symbol(fdecl->getBody());
+    }
   }
   return false;
 }

--- a/testsuite/small/rename-16.c
+++ b/testsuite/small/rename-16.c
@@ -1,0 +1,22 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=main,function -DCE_RENAME_SYMBOLS" }*/
+
+struct AA {
+  void *fun;
+};
+
+int function(void)
+{
+  return 0;
+}
+
+struct AA A = {
+  .fun = function,
+};
+
+int main(void)
+{
+  return (int) ((unsigned long)A.fun & 0xFFFFFFFF);
+}
+
+/* { dg-final { scan-tree-dump "int klpp_function\(void\)" } } */
+/* { dg-final { scan-tree-dump "\.fun = klpp_function," } } */


### PR DESCRIPTION
Previously, FunctionUpdater::Update_References_To_Symbol skipped the variable initializer because DeclaratorDecl::getBody fails to retrieve the initialization Expr once it expects the object to be a function. This commit fixes this by explicitely checking for a VarDecl and getting its initializer.