### PR TITLE
libcextract: ArgvParser: Add -Wno-missing-prototypes

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -79,13 +79,16 @@ ArgvParser::ArgvParser(int argc, char **argv)
 void ArgvParser::Insert_Required_Parameters(void)
 {
   std::vector<const char *> priv_args = {
-     "-fno-builtin", // clang interposes some glibc functions and then it fails to find the declaration of them.
     "-Xclang", "-detailed-preprocessing-record",
-    "-Wno-unused-variable", // Passes may instroduce unused variables later removed.
     // For some reason libtooling do not pass the clang include folder.  Pass this then.
     "-I/usr/lib64/clang/" STRINGFY_VALUE(CLANG_VERSION_MAJOR) "/include",
     "-Wno-gnu-variable-sized-type-not-at-end",
-    "-Wno-unused-function" // May happen when trying to extract a static function.
+    "-Wno-missing-prototypes", // We remove the static keyword from the
+                               // extracted function, so disable warnings
+                               // related to it.
+    "-Wno-unused-function", // May happen when trying to extract a static function.
+    "-Wno-unused-variable", // Passes may instroduce unused variables later removed.
+    "-fno-builtin", // clang interposes some glibc functions and then it fails to find the declaration of them.
   };
 
   for (const char *arg : priv_args) {


### PR DESCRIPTION
Since clang-extract removes the static keyword from the extracted function, and kernel can enable -Werror, avoid the procedure to stop because of missing prototype.