### PR TITLE
Set '.' as a delimiter to the macro tokenizer

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -87,7 +87,7 @@ Get_Range_Of_Identifier_In_SrcRange(const SourceRange &range, const char *id)
 
   /* Tokenize away the function-like macro stuff or expression, we only want
      the identifier.  */
-  const char *token_vector = " (),;+-*/^|&{}[]<>^&|\r\n\t";
+  const char *token_vector = " ().,;+-*/^|&{}[]<>^&|\r\n\t";
 
   /* Create temporary buff, strtok modifies it.  */
   unsigned len = string.size();

--- a/testsuite/small/macro-20.c
+++ b/testsuite/small/macro-20.c
@@ -1,0 +1,16 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_EXPORT_SYMBOLS=struct_variable -DCE_RENAME_SYMBOLS" }*/
+
+struct AA {
+  int aa;
+};
+
+struct AA struct_variable;
+
+#define MACRO(x, y) ((x) + (y))
+
+int f(void)
+{
+  return MACRO(struct_variable.aa, 1);
+}
+
+/* { dg-final { scan-tree-dump "MACRO\(\(\*klpe_struct_variable\)\.aa, 1\);" } } */


### PR DESCRIPTION
When sweeping through macros for identifier we must also use '.' in the tokenizer to correctly get accesses to structs in macro parameters. This commit addresses that.