### PR TITLE
Fix potentially wrong code by dropping attributes after RecordDecls

### DIFF
--- a/testsuite/small/record-5.c
+++ b/testsuite/small/record-5.c
@@ -1,0 +1,17 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+#define SMP_CACHE_BYTES 4
+#define ____cacheline_aligned __attribute__((__aligned__(SMP_CACHE_BYTES)))
+
+struct sched_avg {
+  int aa;
+} ____cacheline_aligned;
+
+struct sched_avg sa;
+
+int f(void)
+{
+  return sa.aa;
+}
+
+/* { dg-final { scan-tree-dump "struct sched_avg {\n *int aa;\n} *____cacheline_aligned;" } } */


### PR DESCRIPTION
Previously, clang-extract dropped __attribute__(()) after the definition of a RecordDecl. This could possibly generate wrong code if the __attribute__ is relevant for code layout, for example.

@marcosps Please check if it fixes the wrong code on TOMOYO.

Closes #13