### PR TITLE
FunctionDepsFinder: Fix closure computation not analyzing functions which have a prototype declared after its body

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -30,7 +30,7 @@ jobs:
            llvm16-libclang13 clang16-devel libclang-cpp16
            clang-tools libLLVM16 llvm16 llvm16-devel meson ninja
            python311-psutil python311-pexpect python311-subprocess-tee
-           python311-pytest gcc
+           python311-pytest gcc findutils bash
     - uses: actions/checkout@v2
     - name: meson
       run: meson setup build --buildtype=${{ matrix.build-type }} --native-file ce-native.ini

--- a/libcextract/LLVMMisc.cpp
+++ b/libcextract/LLVMMisc.cpp
@@ -37,55 +37,6 @@ bool Is_Builtin_Decl(const Decl *decl)
   return false;
 }
 
-/** Get a Decl object from its Identifier by looking into a table (O(1)).  */
-const StoredDeclsList &Get_Stored_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const IdentifierInfo &info)
-{
-  TranslationUnitDecl *tu = ast->getASTContext().getTranslationUnitDecl();
-  StoredDeclsMap *map = tu->getLookupPtr();
-  if (map == nullptr) {
-    /* We need to build it.  */
-    map = tu->buildLookup();
-  }
-  assert(map && "Lookup map is null.");
-
-  DeclarationName dn(&info);
-  auto found = map->find(dn);
-  if (found == map->end()) {
-    /* Well, throw to whoever called me.  */
-    throw SymbolNotFoundException(info.getName().str());
-  }
-
-  const StoredDeclsList &x = found->second;
-  return x;
-}
-
-NamedDecl *Get_Decl_From_Identifier(ASTUnit *ast, const IdentifierInfo &info)
-{
-  return Get_Stored_Decl_List_From_Identifier(ast, info).getAsDecl();
-}
-
-/** Get a Decl object from its Identifier by looking into a table (O(1)).  */
-NamedDecl *Get_Decl_From_Identifier(ASTUnit *ast, const StringRef &name)
-{
-  IdentifierTable &IdTbl = ast->getPreprocessor().getIdentifierTable();
-  return Get_Decl_From_Identifier(ast, IdTbl.get(name));
-}
-
-const DeclContextLookupResult Get_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const IdentifierInfo &info)
-{
-  const StoredDeclsList &list = Get_Stored_Decl_List_From_Identifier(ast, info);
-  return list.getLookupResult();
-}
-
-const DeclContextLookupResult Get_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const StringRef &name)
-{
-  IdentifierTable &IdTbl = ast->getPreprocessor().getIdentifierTable();
-  return Get_Decl_List_From_Identifier(ast, IdTbl.get(name));
-}
-
 /** Build CallGraph from AST.
  *
  * The CallGraph is a datastructure in which nodes are functions and edges

--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -42,23 +42,6 @@ using namespace clang;
 /** Check if Decl is a builtin.  */
 bool Is_Builtin_Decl(const Decl *decl);
 
-/** Get a Decl object from its Identifier by looking into a table (O(1)).  */
-NamedDecl *Get_Decl_From_Identifier(ASTUnit *ast, const IdentifierInfo &info);
-
-/** Get a Decl object from its Identifier by looking into a table (O(1)).  */
-NamedDecl *Get_Decl_From_Identifier(ASTUnit *ast, const StringRef &name);
-
-/** Get a list of Decls from its Identifier by looking into a table.  */
-const DeclContextLookupResult Get_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const IdentifierInfo &info);
-
-/** Get a list of Decls from its Identifier by looking into a table.  */
-const DeclContextLookupResult Get_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const StringRef &name);
-
-const StoredDeclsList &Get_Stored_Decl_List_From_Identifier(ASTUnit *ast,
-                                                            const IdentifierInfo &info);
-
 /** Build CallGraph from AST.
  *
  * The CallGraph is a datastructure in which nodes are functions and edges

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -20,8 +20,8 @@ returncode_to_bool = [ true, false ]
 
 foreach test_dir : ordinary_test_dirs
   subdir(test_dir) # Only here for meson to build the directory.
-  grabber = 'find ' + test_dir + ' -name *.c -o -name *.cpp'
-  test_files = run_command('sh', '-c', grabber, check: true).stdout().strip().split('\n')
+  test_files = run_command('find', test_dir, '-name', '*.c', '-o', '-name', '*.cpp',
+                           check: true).stdout().strip().split('\n')
 
   foreach file : test_files
     test_path = meson.current_source_dir() + '/' + file

--- a/testsuite/small/attr-7.c
+++ b/testsuite/small/attr-7.c
@@ -1,0 +1,16 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+int a __attribute__((unused));
+
+#define __aligned(x) __attribute__((__aligned__(x)))
+
+struct S
+{
+  int a;
+} __aligned(32);
+
+int f(struct S *s)
+{
+  return s->a;
+}
+
+/* { dg-final { scan-tree-dump "} __aligned\(32\);" } } */

--- a/testsuite/small/closure-3.c
+++ b/testsuite/small/closure-3.c
@@ -1,0 +1,14 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+void f(void);
+
+void sink(void);
+
+void f(void)
+{
+  sink();
+}
+
+extern void f(void);
+
+/* { dg-final { scan-tree-dump "void sink\(void\);" } } */


### PR DESCRIPTION
clang has a mechanism (DeclContext::lookup) which is **SUPPOSED TO** return the list of all Decls that matches the lookup name.  However, this method doesn't work as intented.  In kernel (see github issue #20) it results in the lookup_result set not having the Decl that has the body of the function, which is the most important!

Therefore, we fallback to the older but slower method: sweep through the AST top level looking for the Decls we want to extract.

If this issue in the symbol name hash comes from a bug in LLVM, this still needs investigation. 