### PR TITLE
Fix SymbolExternalizer skipping symbols in typeof()

### DIFF
--- a/contrib/suse-install-llvm.sh
+++ b/contrib/suse-install-llvm.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+LLVM_VERSION_NUMBER=$1
+
+if [ "$LLVM_VERSION_NUMBER" = "" ]; then
+  echo "Error: expected a number to be passed as argument."
+  echo ""
+  echo "Usage: suse-install-llvm.sh <NUMBER>"
+  exit 1
+fi
+
+sudo zypper install libLLVM$LLVM_VERSION_NUMBER \
+                    libLLVM$LLVM_VERSION_NUMBER-debuginfo \
+                    llvm$LLVM_VERSION_NUMBER \
+                    llvm$LLVM_VERSION_NUMBER-devel \
+                    llvm$LLVM_VERSION_NUMBER-debuginfo \
+                    clang$LLVM_VERSION_NUMBER \
+                    clang$LLVM_VERSION_NUMBER-debuginfo \
+                    libclang-cpp$LLVM_VERSION_NUMBER-debuginfo \
+                    libclang-cpp$LLVM_VERSION_NUMBER-debuginfo \
+                    libclang-cpp$LLVM_VERSION_NUMBER \
+                    clang$LLVM_VERSION_NUMBER-devel

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -192,6 +192,7 @@ class SymbolExternalizer
     /** Sweeps the function and update any reference to the old function, replacing
         it with the externalized variable.  */
     bool Update_References_To_Symbol(DeclaratorDecl *to_update);
+    bool Update_References_To_Symbol(Stmt *);
 
     private:
 
@@ -200,8 +201,6 @@ class SymbolExternalizer
 
     /* Do we need to wrap the use in (*name)?  */
     bool Wrap;
-
-    bool Update_References_To_Symbol(Stmt *);
   };
   friend class FunctionUpdater;
 

--- a/testsuite/lib/runtest.py
+++ b/testsuite/lib/runtest.py
@@ -57,10 +57,19 @@ if __name__ == '__main__':
         exit(1)
 
     # Run test.
+    r = 0
     test = libtest.UnitTest(input_path, logfile_path, binaries_path)
     if is_inline_test:
         r = test.run_inline_test(is_lto_test)
     else:
         r = test.run_test(is_lto_test)
+
+    # Call the destructor to close the log file.
+    del test
+    # Report the content of the files
+    if r != 0:
+        log = open(logfile_path, "r")
+        print(log.read())
+        log.close()
 
     exit(r)

--- a/testsuite/small/rename-17.c
+++ b/testsuite/small/rename-17.c
@@ -1,0 +1,16 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_RENAME_SYMBOLS -DCE_EXPORT_SYMBOLS=symbol" }*/
+
+struct AA {
+  int aa;
+};
+
+extern struct AA symbol;
+
+int f(void)
+{
+  typeof(symbol) ls = (typeof(symbol)) { 0 };
+  return ls.aa;
+}
+
+/* { dg-final { scan-tree-dump "typeof\(\(\*klpe_symbol\)\) ls = \(typeof\(\(\*klpe_symbol\)\)\) " } } */
+/* { dg-final { scan-tree-dump-not "typeof\(symbol\)" } } */


### PR DESCRIPTION
Previously, the SymbolExternalizer did not run on TypeOfTypeExpr, causing constructions such as
```
typeof(symbol_to_externalize) x;
```
to fail compilation because `symbol_to_externalize` was renamed to something else.  Fix this by hacking a RecursiveASTVisitor that parses all types in the function and update the reference.

Fixes #24