### PR TITLE
SymbolExternalizer: Always emit KLP_RELOC_SYMBOL

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -821,14 +821,17 @@ bool SymbolExternalizer::_Externalize_Symbol(const std::string &to_externalize,
           std::string o;
           llvm::raw_string_ostream outstr(o);
 
-          if (Ibt && !EmittedLinuxLivepatch) {
+          /*
+           * It won't be a problem to add the code below multiple times, since
+           * clang-extract will remove ifndefs for already defined macros
+           */
+          if (Ibt) {
             outstr << "#ifndef KLP_RELOC_SYMBOL_POS\n"
                       "# define KLP_RELOC_SYMBOL_POS(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME, SYM_POS) \\\n"
                       "   asm(\"\\\".klp.sym.rela.\" #LP_OBJ_NAME \".\" #SYM_OBJ_NAME \".\" #SYM_NAME \",\" #SYM_POS \"\\\"\")\n"
                       "# define KLP_RELOC_SYMBOL(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME) \\\n"
                       "   KLP_RELOC_SYMBOL_POS(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME, 0)\n"
                       "#endif\n\n";
-            EmittedLinuxLivepatch = true;
           }
 
           new_decl->print(outstr, AST->getLangOpts());

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -192,7 +192,6 @@ class SymbolExternalizer
       TM(ast, dump),
       IA(ia),
       Ibt(ibt),
-      EmittedLinuxLivepatch(false),
       PatchObject(patch_object)
   {
   }
@@ -295,9 +294,6 @@ class SymbolExternalizer
 
   /** Defines the method that a private symbol will be searched. */
   bool Ibt;
-
-  /** Flag if we already emit the #include<linux/livepatch.h>  */
-  bool EmittedLinuxLivepatch;
 
   /* Name of the object that will be patched. */
   std::string PatchObject;


### PR DESCRIPTION
Currently clang-extract removes ifndefs of macros that are already defined, so always emitting KLP_RELOC_SYMBOL under an ifdef will always emit it before the first usage.

Suggested-by: Giuliano Belinassi <gbelinassi@suse.de>