### PR TITLE
ArgvParser: Disable incompatible-pointer-types-discard-qualifiers

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -88,6 +88,7 @@ void ArgvParser::Insert_Required_Parameters(void)
     // For some reason libtooling do not pass the clang include folder.  Pass this then.
     "-I/usr/lib64/clang/" STRINGFY_VALUE(CLANG_VERSION_MAJOR) "/include",
     "-Wno-gnu-variable-sized-type-not-at-end",
+    "-Wno-incompatible-pointer-types-discards-qualifiers", // this can be triggered for older codestreams
     "-Wno-missing-prototypes", // We remove the static keyword from the
                                // extracted function, so disable warnings
                                // related to it.


### PR DESCRIPTION
This can be happen on older codestreams, so don't bother erroring out in those cases.