### PR TITLE
testsuite: linux: ibt-2: Do not check for livepatch.h

### DIFF
--- a/testsuite/linux/ibt-2.c
+++ b/testsuite/linux/ibt-2.c
@@ -1,8 +1,5 @@
 /* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_SYMVERS_PATH=../testsuite/linux/Modules.symvers -DCE_RENAME_SYMBOLS -nostdinc -I../testsuite/linux -DKBUILD_MODNAME=libcrc32c -D__USE_IBT__ -D__KERNEL__ -DCE_KEEP_INCLUDES" } */
 
-/* Check why the include is not being output.  */
-/* { dg-xfail }*/
-
 typedef unsigned int u32;
 
 u32 crc32c(u32 crc, const void *address, unsigned int length);
@@ -17,7 +14,6 @@ int f(void)
 	return 0;
 }
 
-/* { dg-final { scan-tree-dump "#include <linux/livepatch.h>" } } */
 /* { dg-final { scan-tree-dump "u32 klpe_crc32c|u32 \(klpe_crc32c\)" } } */
 /* { dg-final { scan-tree-dump "KLP_RELOC_SYMBOL\(libcrc32c, libcrc32c, crc32c\)" } } */
 /* { dg-final { scan-tree-dump-not "\(\*klpe_crc32c\)" } } */


### PR DESCRIPTION
We don't include this file anymore, now we output the KLP_RELOC_SYMBOL macro instead. The test is now passing.