### PR TITLE
SymbolExternalizer: Use visitor to get the array size expression

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -133,6 +133,22 @@ class TypeUpdaterVisitor : public RecursiveASTVisitor<TypeUpdaterVisitor>
     return VISITOR_CONTINUE;
   }
 
+  /* To handle symbol renames on situations like the sizeof below
+   *
+   * static char x[4];
+   *
+   * void f(void) {
+   *    char y[sizeof(x)];
+   * }
+   */
+  bool VisitArrayTypeLoc(const ArrayTypeLoc &type)
+  {
+    SymbolExternalizer::FunctionUpdater fu(SE, NewSymbolDecl, OldSymbolName, Wrap);
+    fu.Update_References_To_Symbol(type.getSizeExpr());
+
+    return VISITOR_CONTINUE;
+  }
+
   private:
 
   /** A reference to SymbolExternalizer.  */
@@ -512,35 +528,6 @@ bool SymbolExternalizer::FunctionUpdater::Update_References_To_Symbol(Stmt *stmt
       /* Replace reference with the rewiten name.  */
       expr->setDecl(NewSymbolDecl);
       replaced = true;
-    }
-  } else if (DeclStmt::classof(stmt)) {
-    /* To handle symbol renames on situations like the sizeof below
-     *
-     * static char x[4];
-     *
-     * void f(void) {
-     *    char y[sizeof(x)];
-     * }
-     */
-    DeclStmt *dstmt = (DeclStmt *) stmt;
-    if (VarDecl *ddecl = dyn_cast<VarDecl>(dstmt->getSingleDecl())) {
-      auto vec_of_ranges = Get_Range_Of_Identifier_In_SrcRange(ddecl->getSourceRange(),
-                                                               OldSymbolName.c_str());
-
-      if (vec_of_ranges.size() > 0) {
-        /* Prepare the text modification.  */
-        std::string new_name;
-        if (Wrap) {
-          new_name = NewSymbolDecl->getName().str();
-        } else {
-          new_name = "(*" + NewSymbolDecl->getName().str() + ")";
-        }
-
-        for (auto irange : vec_of_ranges) {
-          /* Issue a text modification.  */
-          SE.Replace_Text(irange, new_name, 100);
-        }
-      }
     }
   }
 

--- a/testsuite/ccp/ext-obj-5.c
+++ b/testsuite/ccp/ext-obj-5.c
@@ -6,12 +6,11 @@ static char ee_o[] = "123";
 
 void pu_f(void)
 {
-        char s[sizeof(ee_o)];
-	char t[sizeof(ee_o)][sizeof(ee_o)];
+        char s[sizeof(ee_o)], t[sizeof(ee_o)][sizeof(ee_o)];
 	static_assert(sizeof(s) == 4);
 	static_assert(sizeof(t) == 16);
         ee_o;
 }
 
 /* { dg-final { scan-tree-dump "static char \(\*klpe_ee_o\)\[4\];" } } */
-/* { dg-final { scan-tree-dump "char s\[sizeof\(\(\*klpe_ee_o\)\)\];" } } */
+/* { dg-final { scan-tree-dump "char s\[sizeof\(\(\*klpe_ee_o\)\)\], t\[sizeof\(\(\*klpe_ee_o\)\)\]\[sizeof\(\(\*klpe_ee_o\)\)\];" } } */


### PR DESCRIPTION
Extend current ccp test to catch a regression found.