### PR TITLE
README.md: Update deps install to use LLVM18

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ clang-extract requires clang, LLVM, libelf, python3-pexpect, python3-psuti,
 meson and ninja in order to build.
 On openSUSE, you can install them by running:
 ```
-$ sudo zypper install clang16 clang16-devel libclang-cpp16 \
-       clang-tools libLLVM16 llvm16 llvm16-devel libelf-devel meson ninja \
+$ sudo zypper install clang18 clang18-devel libclang-cpp18 \
+       clang-tools libLLVM18 llvm18 llvm18-devel libelf-devel meson ninja \
        python311-psutil python311-pexpect python311-subprocess-tee python311-pytest
 ```
-Older versions of clang and LLVM may also work, but is untested. We currently support
-clang 16 or higher.
+It's advised to use LLVM 18 and higher, since it's well tested. But there
+support for LLVM 16 and 17 as well, but you might find issues with it.
 
 Once you have all those packages installed, you must setup the meson build system in order
 to compile. You can run either `build-debug.sh` for a debug build with no optimization


### PR DESCRIPTION
LLVM16 generates wrong C attributes, and this was fixed on LLVM18. Update the dependency install command to suggest people to use LLVM18 instead.