### PR TITLE
Fix SymbolExternalizer wrapping when IBT is enabled

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -813,7 +813,7 @@ bool SymbolExternalizer::_Externalize_Symbol(const std::string &to_externalize,
        externalized.  */
     if (must_update) {
       /* Call our hack to update the TypeOfTypes.  */
-      TypeUpdaterVisitor(*this, new_decl, to_externalize, wrap)
+      TypeUpdaterVisitor(*this, new_decl, to_externalize, wrap || Ibt)
         .TraverseDecl(decl);
 
       FunctionUpdater(*this, new_decl, to_externalize, wrap || Ibt)

--- a/testsuite/linux/ibt-typeof-1.c
+++ b/testsuite/linux/ibt-typeof-1.c
@@ -1,0 +1,21 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_SYMVERS_PATH=../testsuite/linux/Modules.symvers -DCE_RENAME_SYMBOLS -nostdinc -I../testsuite/linux -DKBUILD_MODNAME=libcrc32c -D__USE_IBT__ -D__KERNEL__ -DCE_KEEP_INCLUDES" } */
+
+typedef unsigned int u32;
+
+u32 crc32c(u32 crc, const void *address, unsigned int length);
+
+int f(void)
+{
+	u32 lcrc = 0;
+	void *addr = 0;
+	unsigned int len = 0;
+  typeof(crc32c) *ptr = (void *) 0UL;
+
+	(void)crc32c(lcrc, addr, len);
+	return 0;
+}
+
+/* { dg-final { scan-tree-dump "u32 klpe_crc32c|u32 \(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump "KLP_RELOC_SYMBOL\(libcrc32c, libcrc32c, crc32c\)" } } */
+/* { dg-final { scan-tree-dump "typeof\(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump-not "\(\*klpe_crc32c\)" } } */


### PR DESCRIPTION
When constructing the TypeUpdateVisitor we should OR with Ibt so it does not wrap the use of the symbol with (*s).