### PR TITLE
testsuite: attr: Adapt testcase to be executed on ppc64le

### DIFF
--- a/testsuite/small/attr-1.c
+++ b/testsuite/small/attr-1.c
@@ -4,6 +4,8 @@
 register unsigned long current_stack_pointer asm("rsp");
 #elif __aarch64__
 register unsigned long current_stack_pointer asm("sp");
+#elif __PPC64__
+register unsigned long current_stack_pointer asm("r1");
 #endif
 
 unsigned long f()

--- a/testsuite/small/attr-6.c
+++ b/testsuite/small/attr-6.c
@@ -4,6 +4,8 @@
 #define REG "rsp"
 #elif __aarch64__
 #define REG "sp"
+#elif __PPC64__
+#define REG "r1"
 #endif
 
 register unsigned long current_stack_pointer asm(REG);
@@ -13,6 +15,6 @@ unsigned long f()
   return current_stack_pointer;
 }
 
-/* { dg-final { scan-tree-dump "#define REG \"(rsp|sp)\"" } } */
+/* { dg-final { scan-tree-dump "#define REG \"(rsp|sp|r1)\"" } } */
 /* { dg-final { scan-tree-dump "current_stack_pointer asm\(REG\)" } } */
 /* { dg-final { scan-tree-dump "unsigned long f" } } */


### PR DESCRIPTION
ppc64le uses a different register to get the current stack pointer.