### PR TITLE
Noinline fix

### DIFF
--- a/libcextract/PrettyPrint.hh
+++ b/libcextract/PrettyPrint.hh
@@ -80,14 +80,14 @@ class PrettyPrint
 
   static bool Contains(const SourceRange &a, const SourceRange &b);
 
-  static inline void Set_Source_Manager(SourceManager *sm)
+  static inline void Set_AST(ASTUnit *ast)
   {
-    SM = sm;
+    AST = ast;
   }
 
   static inline SourceManager *Get_Source_Manager(void)
   {
-    return SM;
+    return &AST->getSourceManager();
   }
 
   static inline LangOptions &Get_Lang_Options(void)
@@ -153,9 +153,10 @@ class PrettyPrint
   /** Policy for printing.  We use the default for now.  */
   static PrintingPolicy PPolicy;
 
-  /** SourceManager built when parsing the AST.  Must be set after constructing
-      the ast by calling Set_Source_Manager.  */
-  static SourceManager *SM;
+  /** ASTUnit object.  Must be set after constructing the ast by
+      calling Set_Source_Manager.  FIXME: This should not be a statc
+      class variable.  Refactor this class entirely.  */
+  static ASTUnit *AST;
 
   friend class RecursivePrint;
 };

--- a/testsuite/small/attr-8.c
+++ b/testsuite/small/attr-8.c
@@ -1,0 +1,13 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=func_f -DCE_NO_EXTERNALIZATION" }*/
+#define MACRO 0
+
+/* Do this sort of blurry definition to confuse out clang-extract into dumping
+   the AST of the function.  */
+#define DEFINE_FUNCTION(name) __attribute__((noinline)) int func_##name(void) { return MACRO; }
+#define DEFINE_VARIABLE(name) int var_##name;
+#define DEFINE(f) DEFINE_VARIABLE(f) DEFINE_FUNCTION(f)
+
+DEFINE(f)
+
+/* { dg-final { scan-tree-dump "__attribute__\(\(noinline\)\)" } } */
+/* { dg-final { scan-tree-dump-not "#define noinline" } } */

--- a/testsuite/small/attr-9.c
+++ b/testsuite/small/attr-9.c
@@ -1,0 +1,33 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=func_f,g,h -DCE_NO_EXTERNALIZATION" }*/
+
+
+#define noinline SHOULD_NOT_BE_IN_THE_FINAL_OUTPUT
+
+#undef noinline
+#define noinline __attribute__((__noinline__))
+
+/* Do this sort of blurry definition to confuse out clang-extract into dumping
+   the AST of the function.  */
+#define DEFINE_FUNCTION(name) noinline int func_##name(void) { return 0; }
+#define DEFINE_VARIABLE(name) int var_##name;
+#define DEFINE(f) DEFINE_VARIABLE(f) DEFINE_FUNCTION(f)
+
+noinline int g()
+{
+  return 1;
+}
+
+DEFINE(f);
+
+noinline int h()
+{
+  return 2;
+}
+
+
+#undef noinline
+#define noinline SHOULD_NOT_BE_IN_THE_FINAL_OUTPUT
+
+/* { dg-final { scan-tree-dump "__attribute__\(\(noinline\)\) int func_f|int func_f\(void\) __attribute__\(\(noinline\)\)" } } */
+/* { dg-final { scan-tree-dump "#undef noinline" } } */
+/* { dg-final { scan-tree-dump-not "SHOULD_NOT_BE_IN_THE_FINAL_OUTPUT" } } */


### PR DESCRIPTION
Undefine noinline macro if conflicts with AST dump

In kernel sourcecode there is a definition of a macro:
```
#define noinline __attribute__((noinline))
```

This seems harmless, but when clang-extract decides to dump the AST of
a Decl, this conflicts with its attr:
```
__attribute__((noinline))
```
which results in the resulting code being broken. Hence, undefine this
macro for the AST dump and define it later.

Closes #15

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>
