### PR TITLE
libcextract: SymbolExternalizer: Drop klpe_ prefix if IBT is specified

### DIFF
--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -100,6 +100,23 @@ struct SymbolUpdateStatus
     return OldDecl && NewDecl && FirstUse;
   }
 
+  /* For IBT, NewDecl and OldDecl are the same if the symbols is a function, so
+     don't replace text if the name didn't change. */
+  inline bool Needs_Sym_Rename(void) {
+    if (NewDecl == nullptr)
+      return true;
+
+    return NewDecl->getName() != OldDecl->getName();
+    /*
+    llvm::outs() << "XX OldName" << "\n";
+    llvm::outs() << OldDecl->getName() << "\n";
+    llvm::outs() << "XX NewName print" << "\n";
+    NewDecl->print(llvm::outs(), 0);
+    llvm::outs() << "XX NewName name" << "\n";
+    llvm::outs() << NewDecl->getName() << "\n";
+    */
+  }
+
   void Dump(SourceManager &SM)
   {
     llvm::outs() << "SymbolUpdateStatus at 0x" << this << '\n';

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -343,6 +343,9 @@ class SymbolExternalizer
   /* Drop `static` keyword in decl.  */
   bool Drop_Static(FunctionDecl *decl);
 
+  /* Replace `static` keyword in decl with extern.  */
+  bool Add_Extern(FunctionDecl *decl);
+
   /** Commit changes to the loaded source file buffer.  Should NOT modify the
       original file, only the content that was loaded in llvm's InMemory file
       system.  */

--- a/testsuite/linux/ibt-1.c
+++ b/testsuite/linux/ibt-1.c
@@ -14,6 +14,6 @@ int f(void)
 	return 0;
 }
 
-/* { dg-final { scan-tree-dump "u32 klpe_crc32c|u32 \(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump "u32 \(crc32c\)\(" } } */
 /* { dg-final { scan-tree-dump "KLP_RELOC_SYMBOL\(libcrc32c, libcrc32c, crc32c\)" } } */
 /* { dg-final { scan-tree-dump-not "\(\*klpe_crc32c\)" } } */

--- a/testsuite/linux/ibt-2.c
+++ b/testsuite/linux/ibt-2.c
@@ -14,6 +14,6 @@ int f(void)
 	return 0;
 }
 
-/* { dg-final { scan-tree-dump "u32 klpe_crc32c|u32 \(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump "u32 \(crc32c\)\(" } } */
 /* { dg-final { scan-tree-dump "KLP_RELOC_SYMBOL\(libcrc32c, libcrc32c, crc32c\)" } } */
 /* { dg-final { scan-tree-dump-not "\(\*klpe_crc32c\)" } } */

--- a/testsuite/linux/ibt-typeof-1.c
+++ b/testsuite/linux/ibt-typeof-1.c
@@ -15,7 +15,7 @@ int f(void)
 	return 0;
 }
 
-/* { dg-final { scan-tree-dump "u32 klpe_crc32c|u32 \(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump "u32 \(crc32c\)\(" } } */
 /* { dg-final { scan-tree-dump "KLP_RELOC_SYMBOL\(libcrc32c, libcrc32c, crc32c\)" } } */
-/* { dg-final { scan-tree-dump "typeof\(klpe_crc32c\)" } } */
+/* { dg-final { scan-tree-dump "typeof\(crc32c\)" } } */
 /* { dg-final { scan-tree-dump-not "\(\*klpe_crc32c\)" } } */


### PR DESCRIPTION
The resulting code would be exactly the same as the original code, or at least as much as it can be the same.