### PR TITLE
Fix location comment of LateExternalized variables

### DIFF
--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -77,3 +77,15 @@ Decl         *Get_Bodyless_Or_Itself(Decl *decl);
 
 /* Get the TopLevel Decl that contains the location loc.  */
 Decl *Get_Toplevel_Decl_At_Location(ASTUnit *ast, const SourceLocation &loc);
+
+/** Build a clang-extract location comment.  */
+std::string Build_CE_Location_Comment(SourceManager &sm, const SourceLocation &loc);
+
+/** Get the begin location of the Decl before its comment if it have one.  */
+SourceLocation Get_Begin_Loc_Of_Decl_Or_Comment(ASTContext &ctx, Decl *decl);
+
+/** Get decl clang-extract location comment, or build one if it doesn't exist.  */
+std::string Get_Or_Build_CE_Location_Comment(ASTContext &ctx, Decl *decl);
+
+/** Check if Decl have a Location comment.  */
+bool Have_Location_Comment(const SourceManager &sm, RawComment *comment);

--- a/libcextract/PrettyPrint.cpp
+++ b/libcextract/PrettyPrint.cpp
@@ -17,6 +17,7 @@
 #include "ClangCompat.hh"
 #include "TopLevelASTIterator.hh"
 #include "NonLLVMMisc.hh"
+#include "LLVMMisc.hh"
 
 #include <clang/AST/Attr.h>
 
@@ -236,6 +237,11 @@ void PrettyPrint::Print_Attr(Attr *attr)
 void PrettyPrint::Print_Comment(const std::string &comment)
 {
   Out << "/** " << comment << "  */\n";
+}
+
+void PrettyPrint::Print_Raw(const std::string &string)
+{
+  Out << string;
 }
 
 void PrettyPrint::Print_RawComment(SourceManager &sm, RawComment *comment)
@@ -525,17 +531,6 @@ void RecursivePrint::Print_Preprocessed(PreprocessedEntity *prep)
   }
 }
 
-static bool Have_Location_Comment(const SourceManager &sm, RawComment *comment)
-{
-  if (comment) {
-    StringRef text = comment->getRawText(sm);
-    if (prefix("/** clang-extract: from ", text.data())) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void RecursivePrint::Print_Decl(Decl *decl)
 {
   if (!Is_Decl_Marked(decl)) {
@@ -564,14 +559,8 @@ void RecursivePrint::Print_Decl(Decl *decl)
     RawComment *comment = ctx.getRawCommentForDeclNoCache(decl);
     if (decl->getBeginLoc().isValid()) {
       if (!Have_Location_Comment(sm, comment)) {
-        PresumedLoc presumed = sm.getPresumedLoc(decl->getBeginLoc());
-        unsigned line = presumed.getLine();
-        unsigned col = presumed.getColumn();
-        const std::string &filename = sm.getFilename(decl->getBeginLoc()).str();
-
-        std::string comment = "clang-extract: from " + filename + ":" +
-                              std::to_string(line) + ":" + std::to_string(col);
-        PrettyPrint::Print_Comment(comment);
+        std::string comment = Build_CE_Location_Comment(sm, decl->getBeginLoc());
+        PrettyPrint::Print_Raw(comment);
       } else {
         /* Just output what it had.  */
         PrettyPrint::Print_RawComment(sm, comment);

--- a/libcextract/PrettyPrint.hh
+++ b/libcextract/PrettyPrint.hh
@@ -72,6 +72,8 @@ class PrettyPrint
 
   static void Print_Comment(const std::string &comment);
 
+  static void Print_Raw(const std::string &string);
+
   static void Print_RawComment(SourceManager &sm, RawComment *comment);
 
   static void Debug_SourceLoc(const SourceLocation &loc);

--- a/testsuite/lateext/location-1.c
+++ b/testsuite/lateext/location-1.c
@@ -1,0 +1,11 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_EXPORT_SYMBOLS=global -DCE_KEEP_INCLUDES -DCE_LATE_EXTERNALIZE" }*/
+
+#include "location-1.h"
+
+int f(void)
+{
+  return global;
+}
+
+/* { dg-final { scan-tree-dump "static int \*klpe_global;" } } */
+/* { dg-final { scan-tree-dump "clang-extract: from .*location-1.h:29:1" } } */

--- a/testsuite/lateext/location-1.h
+++ b/testsuite/lateext/location-1.h
@@ -1,0 +1,33 @@
+/* Get it that down to make sure the location to not clash with anything
+   else.  */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+int global = 1;
+
+
+
+


### PR DESCRIPTION
When a variable is externalized through LateExternalization, we also have to carry the comment location of the OldDecl to the NewDecl once we are not replacing the text in the same SourceRange the OldDecl was. This commit fixes this by inserting this comment on the text of the NewDecl.