### PR TITLE
Fix dropped attributes from vector types

### DIFF
--- a/libcextract/Closure.hh
+++ b/libcextract/Closure.hh
@@ -444,6 +444,14 @@ class DeclClosureVisitor : public RecursiveASTVisitor<DeclClosureVisitor>
     return VISITOR_CONTINUE;
   }
 
+  bool VisitConvertVectorExpr(const ConvertVectorExpr *expr)
+  {
+    const TypeSourceInfo *tsi = expr->getTypeSourceInfo();
+    TRY_TO(TraverseTypeLoc(tsi->getTypeLoc()));
+
+    return VISITOR_CONTINUE;
+  }
+
   /* -------- Types ----------------- */
   bool VisitTagType(const TagType *type)
   {

--- a/libcextract/PrettyPrint.cpp
+++ b/libcextract/PrettyPrint.cpp
@@ -357,6 +357,15 @@ SourceLocation PrettyPrint::Get_Expanded_Loc(Decl *decl)
     bool has_attr = false;
     SourceManager &SM = AST->getSourceManager();
 
+    /* Vector type attributes are not encoded in the AttrVec structure, hence
+       we have to check for its existence and expand until we match the ';'
+       token.  See small/attr-11.c testcase.  */
+    if (TypedefDecl *tdecl = dyn_cast<TypedefDecl>(decl)) {
+      if (isa<clang::VectorType>(tdecl->getTypeSourceInfo()->getType().getTypePtr())) {
+        has_attr = true;
+      }
+    }
+
     for (size_t i = 0; i < attrvec.size(); i++) {
       const Attr *attr = attrvec[i];
       SourceLocation loc = attr->getRange().getEnd();

--- a/testsuite/small/attr-11.c
+++ b/testsuite/small/attr-11.c
@@ -1,0 +1,13 @@
+/* { dg-options "-Wno-everything -DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+typedef long long __m64 __attribute__((__vector_size__(8), __aligned__(8)));
+
+typedef int __v2si __attribute__((__vector_size__(8)));
+
+__v2si f(void)
+{
+  __v2si _0 = {0, 0};
+  return _0;
+}
+
+/* { dg-final { scan-tree-dump "typedef int __v2si __attribute__\(\(__vector_size__\(8\)\)\);" } } */

--- a/testsuite/small/vectortype-1.c
+++ b/testsuite/small/vectortype-1.c
@@ -1,0 +1,16 @@
+/* { dg-options "-Wno-everything -DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+typedef float __v8sf __attribute__ ((__vector_size__ (32)));
+
+typedef unsigned int __v8su __attribute__ ((__vector_size__ (32)));
+
+typedef float __m256 __attribute__ ((__vector_size__ (32), __aligned__(32)));
+
+typedef long long __m256i __attribute__((__vector_size__(32), __aligned__(32)));
+
+__m256 __attribute__((__nodebug__, __min_vector_width__(256)))
+f (__m256i __A) {
+  return (__m256)__builtin_convertvector((__v8su)__A, __v8sf);
+}
+
+/* { dg-final { scan-tree-dump "typedef float __v8sf __attribute__ \(\(__vector_size__ \(32\)\)\);" } } */


### PR DESCRIPTION
Clang handle __attribute__((__vector_size__((N)))) attributes differently from the general case.  While other attributes resides in the AttrVec structure, those are hardcoded in the VectorType structure and the AttrVec may contain nothing.  Hence we also need to trigger the Get_Expanded_Loc for this case as well even if we can't get the SourceLocation of this attribute.

Closes #68 (I hope for the last time! :) )