### PR TITLE
Fix nested struct being discarded if parent struct is flagged as partial

### DIFF
--- a/testsuite/small/record-nested-3.c
+++ b/testsuite/small/record-nested-3.c
@@ -1,0 +1,19 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=fts3PrefixParameter -DCE_NO_EXTERNALIZATION" }*/
+
+struct Fts3Table {
+  struct Fts3Index {
+    int nPrefix;
+  } *aIndex;
+};
+
+int fts3PrefixParameter(
+  const char *zParam,
+  int *pnIndex,
+  struct Fts3Index **apIndex
+){
+  int a = sizeof(struct Fts3Index);
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump "struct Fts3Table *{" } } */
+/* { dg-final { scan-tree-dump "} *\*aIndex;" } } */


### PR DESCRIPTION
When clang detects that a certain struct doesn't need a full definition, i.e. its size is not required, then the flag CompleteDefinitionRequired is set to false.  But in the following case:
```
struct Fts3Table {
  struct Fts3Index {
    int nPrefix;
  } *aIndex;
};

int fts3PrefixParameter(
  const char *zParam,
  int *pnIndex,
  struct Fts3Index **apIndex
){
  int a = sizeof(struct Fts3Index);
  return 0;
}
```
this results in the nested struct `Fts3Index` not being output as its parent struct `Fts3Table` is marked as CompleteDefinitionRequired as false.  In such cases we have to force CompleteDefinitionRequired of the parent struct as true so that its inner structs can be output.

Fix #77 