### PR TITLE
Replace dynamic_cast with dyn_cast in accordance with Issue #87

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "unordered_set": "cpp"
+    }
+}

--- a/libcextract/EnumConstTbl.cpp
+++ b/libcextract/EnumConstTbl.cpp
@@ -20,7 +20,7 @@ EnumConstantTable::EnumConstantTable(ASTUnit *ast)
 {
   clang::ASTUnit::top_level_iterator it;
   for (it = ast->top_level_begin(); it != ast->top_level_end(); ++it) {
-    EnumDecl *decl = dynamic_cast<EnumDecl *>(*it);
+    EnumDecl *decl = dyn_cast<EnumDecl *>(*it);
 
     if (decl && decl->isThisDeclarationADefinition()) {
       Insert(decl);

--- a/libcextract/FunctionDepsFinder.cpp
+++ b/libcextract/FunctionDepsFinder.cpp
@@ -90,7 +90,7 @@ void FunctionDependencyFinder::Remove_Redundant_Decls(void)
 
         which is a redeclaration of enum Hand. Hence we have to remove the
         first `enum Hand` from the closure.  See typedef-7.c testcase.  */
-    if (TypedefDecl *decl = dynamic_cast<TypedefDecl *>(*it)) {
+    if (TypedefDecl *decl = dyn_cast<TypedefDecl *>(*it)) {
       SourceRange range = decl->getSourceRange();
 
       const clang::Type *type = decl->getTypeForDecl();
@@ -136,7 +136,7 @@ void FunctionDependencyFinder::Remove_Redundant_Decls(void)
         this will remove the first enum declaration because the location
         tracking will correctly include the enum system_states.  */
 
-    else if (DeclaratorDecl *decl = dynamic_cast<DeclaratorDecl *>(*it)) {
+    else if (DeclaratorDecl *decl = dyn_cast<DeclaratorDecl *>(*it)) {
       SourceRange range = decl->getSourceRange();
 
       const clang::Type *type = ClangCompat::getTypePtr(decl->getType());

--- a/libcextract/FunctionExternalizeFinder.cpp
+++ b/libcextract/FunctionExternalizeFinder.cpp
@@ -44,7 +44,7 @@ FunctionExternalizeFinder::FunctionExternalizeFinder(ASTUnit *ast,
 
 bool FunctionExternalizeFinder::Should_Externalize(CallGraphNode *node)
 {
-  return Should_Externalize(dynamic_cast<FunctionDecl *>(node->getDecl()));
+  return Should_Externalize(dyn_cast<FunctionDecl *>(node->getDecl()));
 }
 
 bool FunctionExternalizeFinder::Should_Externalize(const DeclaratorDecl *decl)
@@ -125,7 +125,7 @@ bool FunctionExternalizeFinder::Analyze_Function(FunctionDecl *decl)
 
 bool FunctionExternalizeFinder::Analyze_Node(CallGraphNode *node)
 {
-  FunctionDecl *decl = dynamic_cast<FunctionDecl *>(node->getDecl());
+  FunctionDecl *decl = dyn_cast<FunctionDecl *>(node->getDecl());
 
   if (Is_Already_Analyzed(node)) {
     return false;
@@ -170,7 +170,7 @@ bool FunctionExternalizeFinder::Externalize_DeclRefs(Stmt *stmt)
 
   if (DeclRefExpr::classof(stmt)) {
     DeclRefExpr *expr = (DeclRefExpr *) stmt;
-    DeclaratorDecl *decl = dynamic_cast<DeclaratorDecl *>(expr->getDecl());
+    DeclaratorDecl *decl = dyn_cast<DeclaratorDecl *>(expr->getDecl());
 
     if (Should_Externalize(decl)) {
       externalized = Mark_For_Externalization(decl->getNameAsString());

--- a/libcextract/PrettyPrint.cpp
+++ b/libcextract/PrettyPrint.cpp
@@ -31,9 +31,9 @@ void PrettyPrint::Print_Decl(Decl *decl)
      with body.  If yes, we can simply print the declaration, but otherwise
      we need to manually insert the end of statement ';' token.  */
 
-  FunctionDecl *f = dynamic_cast<FunctionDecl*>(decl);
-  TagDecl *t = dynamic_cast<TagDecl*>(decl);
-  EnumDecl *e = dynamic_cast<EnumDecl*>(decl);
+  FunctionDecl *f = dyn_cast<FunctionDecl*>(decl);
+  TagDecl *t = dyn_cast<TagDecl*>(decl);
+  EnumDecl *e = dyn_cast<EnumDecl*>(decl);
 
   if (f && f->hasBody() && f->isThisDeclarationADefinition()) {
     Print_Decl_Raw(f);
@@ -549,7 +549,7 @@ void RecursivePrint::Print_Decl(Decl *decl)
   /* Handle namespaces.  Namespace declaration can contain many functions
      that can be unused in the program.  Hence we need to handle it
      carefully to remove what we don't need.  */
-  if (NamespaceDecl *namespacedecl = dynamic_cast<NamespaceDecl*>(decl)) {
+  if (NamespaceDecl *namespacedecl = dyn_cast<NamespaceDecl*>(decl)) {
     if (namespacedecl->isInline()) {
        (*PrettyPrint::Out)  << "inline ";
     }


### PR DESCRIPTION
This commit addresses Issue #87, where it was noted that Clang, when compiled without RTTI (Run-Time Type Information), causes dynamic_cast to fail. This failure occurs because dynamic_cast relies on RTTI to safely cast pointers or references across an inheritance hierarchy. In environments where RTTI is disabled, dynamic_cast cannot perform these operations, leading to potential runtime errors.

Replacing dynamic_cast with Clang's dyn_cast<> provides a more reliable alternative in such scenarios. dyn_cast<> performs a similar operation but does not rely on RTTI, making it suitable for use in environments where RTTI is unavailable. It is important to note that dyn_cast<> will return nullptr if the cast is unsuccessful, which should be handled appropriately in the code to avoid dereferencing null pointers.