### PR TITLE
Update copyright headers in clang-extract files

### DIFF
--- a/libcextract/ClangCompat.hh
+++ b/libcextract/ClangCompat.hh
@@ -2,7 +2,6 @@
  *  clang-extract - Extract functions from projects and its dependencies using
  *                  libclang and LLVM infrastructure.
  *
- *  Copyright (C) 2024 SUSE Software Solutions GmbH
  *
  *  This file is part of clang-extract.
  *

--- a/libcextract/ExpansionPolicy.cpp
+++ b/libcextract/ExpansionPolicy.cpp
@@ -15,7 +15,6 @@
  *  clang-extract - Extract functions from projects and its dependencies using
  *                  libclang and LLVM infrastructure.
  *
- *  Copyright (C) 2024 SUSE Software Solutions GmbH
  *
  *  This file is part of clang-extract.
  *

--- a/libcextract/FunctionExternalizeFinder.hh
+++ b/libcextract/FunctionExternalizeFinder.hh
@@ -2,7 +2,6 @@
  *  clang-extract - Extract functions from projects and its dependencies using
  *                  libclang and LLVM infrastructure.
  *
- *  Copyright (C) 2024 SUSE Software Solutions GmbH
  *
  *  This file is part of clang-extract.
  *


### PR DESCRIPTION
This pull request updates the copyright headers in the clang-extract project by removing the outdated SUSE Software copyright text.