### PR TITLE
SymbolExternalizer: Check KLP_ macros only if there was externzalized…

### DIFF
--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -459,7 +459,7 @@ class FunctionExternalizerPass : public Pass
                         ClangCompat_None, ctx->OFS);
       PrettyPrint::Set_AST(ctx->AST.get());
 
-      if (ctx->Ibt && ctx->AST) {
+      if (ctx->Ibt && ctx->AST && externalizer.Has_Externalizations()) {
         /* Do a sanity check on IBT macros.  Some kernel branches can't use it,
            so do a check here for sanity reasons.  */
         Preprocessor &pp = ctx->AST->getPreprocessor();

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -340,6 +340,17 @@ class SymbolExternalizer
     return Log;
   }
 
+  /** Returns true if there was at least one externalized symbol */
+  inline bool Has_Externalizations(void)
+  {
+    for (auto const& [key, val] : SymbolsMap) {
+      if (val.ExtType == ExternalizationType::STRONG)
+        return true;
+    }
+
+    return false;
+  }
+
   /** Dump the SymbolsMap structure into stdout for debugging purposes.  */
   void Dump_SymbolsMap(void);
 


### PR DESCRIPTION
… syms

This fixes some tests where we don't have externalized symbols after the late externalization removes the KLP_ macros.