### PR TITLE
Fix closure missing TypedefDecl because not being referenced by type

### DIFF
--- a/libcextract/LLVMMisc.cpp
+++ b/libcextract/LLVMMisc.cpp
@@ -205,3 +205,18 @@ bool Have_Location_Comment(const SourceManager &sm, RawComment *comment)
   }
   return false;
 }
+
+/** Lookup in the symbol table for a declaration with given name passed by info.  */
+DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const IdentifierInfo *info)
+{
+  TranslationUnitDecl *tu = ast->getASTContext().getTranslationUnitDecl();
+  return tu->lookup(DeclarationName(info));
+}
+
+/** Lookup in the symbol table for a declaration with given name passed by name.  */
+DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const StringRef &name)
+{
+  IdentifierTable &symtab = ast->getPreprocessor().getIdentifierTable();
+  IdentifierInfo &info = symtab.get(name);
+  return Get_Decl_From_Symtab(ast, &info);
+}

--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -89,3 +89,9 @@ std::string Get_Or_Build_CE_Location_Comment(ASTContext &ctx, Decl *decl);
 
 /** Check if Decl have a Location comment.  */
 bool Have_Location_Comment(const SourceManager &sm, RawComment *comment);
+
+/** Lookup in the symbol table for a declaration with given name passed by info.  */
+DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const IdentifierInfo *info);
+
+/** Lookup in the symbol table for a declaration with given name passed by name.  */
+DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const StringRef &name);

--- a/testsuite/small/attr-13.c
+++ b/testsuite/small/attr-13.c
@@ -1,0 +1,14 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+/* { dg-xfail } */
+
+enum MHD_Result {
+    MHD_NO = 0,
+    MHD_YES = 1
+}__attribute__((enum_extensibility(closed)));
+
+enum MHD_Result f() {
+    return MHD_NO;
+}
+
+
+/* { dg-final { scan-tree-dump "__attribute__\(\(enum_externsibility\(closed\)\)\)" } } */

--- a/testsuite/small/typedef-14.c
+++ b/testsuite/small/typedef-14.c
@@ -1,0 +1,11 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+typedef void (*XtErrorHandler)(char *);
+extern void XtSetErrorHandler(XtErrorHandler __attribute((noreturn)));
+
+void f() {
+    XtSetErrorHandler(((void*)0));
+}
+
+/* { dg-final { scan-tree-dump "typedef void \(\*XtErrorHandler\)\(char \*\);" } } */
+

--- a/testsuite/small/typedef-15.c
+++ b/testsuite/small/typedef-15.c
@@ -1,0 +1,23 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+/* { dg-xfail } */
+
+typedef long unsigned int size_t;
+typedef void
+  *(*AcquireMemoryHandler)(size_t),
+  (*DestroyMemoryHandler)(void *),
+  *(*ResizeMemoryHandler)(void *,size_t),
+  *(*AcquireAlignedMemoryHandler)(const size_t,const size_t),
+  (*RelinquishAlignedMemoryHandler)(void *);
+
+extern void
+  GetMagickMemoryMethods(AcquireMemoryHandler *,ResizeMemoryHandler *, DestroyMemoryHandler *),
+  *ResetMagickMemory(void *,int,const size_t);
+
+void f()
+{
+  (void) ResetMagickMemory((void*)0,0,0);
+}
+
+/* { dg-final { scan-tree-dump "\*\(\*AcquireMemoryHandler\)\(size_t\)," } } */
+/* { dg-final { scan-tree-dump "\*\(\*DestroyMemoryHandler\)\(void *\*\)," } } */
+/* { dg-final { scan-tree-dump "\*\(\*ResizeMemoryHandler\)\(void *\*, *size_t\)," } } */

--- a/testsuite/small/typedef-16.c
+++ b/testsuite/small/typedef-16.c
@@ -1,0 +1,34 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+/* { dg-xfail } */
+
+typedef long unsigned int size_t;
+
+typedef struct _MagickWand
+  MagickWand;
+
+typedef enum
+{
+  MagickFalse = 0,
+  MagickTrue = 1
+} MagickBooleanType;
+
+typedef enum
+{
+  UndefinedChannel = 0x0000,
+  RedChannel = 0x0001,
+  GrayChannel = 0x0001,
+} ChannelType;
+
+extern __attribute__ ((visibility ("default"))) MagickBooleanType
+  MagickAdaptiveBlurImage(MagickWand *,const double,const double),
+  MagickAdaptiveResizeImage(MagickWand *,const size_t,const size_t),
+  MagickAdaptiveSharpenImage(MagickWand *,const double,const double);
+
+MagickBooleanType f(MagickWand *wand, const ChannelType channel, const double radius, const double sigma) {
+ MagickBooleanType status;
+ status = MagickAdaptiveSharpenImage(wand, radius, sigma);
+ return status;
+}
+
+/* { dg-final { scan-tree-dump "typedef long unsigned int size_t;" } } */
+/* { dg-final { scan-tree-dump "MagickAdaptiveSharpenImage\(MagickWand *\*,const double, *\*const double\);" } } */


### PR DESCRIPTION
There are some types in which we lose the the typedef reference, for example:

  typedef void (*XtErrorHandler)(char *);
  extern void XtSetErrorHandler(XtErrorHandler __attribute((noreturn)));

The type dump for this is:
```
  FunctionProtoType 0x5210000720e0 'void (void (*)(char *) __attribute__((noreturn)))' cdecl
  |-BuiltinType 0x521000014170 'void'
  `-PointerType 0x521000071fd0 'void (*)(char *) __attribute__((noreturn))'
    `-ParenType 0x521000071f70 'void (char *) __attribute__((noreturn))' sugar
      `-FunctionProtoType 0x521000071f30 'void (char *) __attribute__((noreturn))' noreturn cdecl
        |-BuiltinType 0x521000014170 'void'
        `-PointerType 0x521000014d10 'char *'
          `-BuiltinType 0x5210000141b0 'char'
```
Notice that there is no reference for XtErrorHandler.  Somehow clang was not able to identify that XtErrorHandler __attribute((noreturn)) is a XtErrorHandler.  OTOH, if we drop __attribute((noreturn)) we get:
```
  FunctionProtoType 0x521000071ff0 'void (XtErrorHandler)' cdecl
  |-BuiltinType 0x521000014170 'void'
  `-ElaboratedType 0x521000071f00 'XtErrorHandler' sugar
    `-TypedefType 0x521000071ed0 'XtErrorHandler' sugar
      |-Typedef 0x521000071e78 'XtErrorHandler'
      `-PointerType 0x521000071e10 'void (*)(char *)'
        `-ParenType 0x521000071db0 'void (char *)' sugar
          `-FunctionProtoType 0x521000071d70 'void (char *)' cdecl
            |-BuiltinType 0x521000014170 'void'
            `-PointerType 0x521000014d10 'char *'
              `-BuiltinType 0x5210000141b0 'char'
```
which is correct.  Hence we get the SourceText and try to match to any decl that is in the symbol table with that name.

This also adds two testcases for the ImageMagick sourcecode (see issue #94) , which are still failing.