### PR TITLE
libcextract: Add support for Weak symbols for kernel mode

### DIFF
--- a/libcextract/InlineAnalysis.cpp
+++ b/libcextract/InlineAnalysis.cpp
@@ -296,6 +296,12 @@ ExternalizationType InlineAnalysis::Needs_Externalization(const std::string &sym
 {
   if (Symv) {
     const std::string &sym_mod = Symv->Get_Symbol_Module(sym);
+    /* If the symbol comes from vmlinux, then we should use Weak
+     * externalization, since the symbol is always present when loading the
+     * livepatch. */
+    if (sym_mod == "vmlinux")
+      return ExternalizationType::WEAK;
+
     /*
      * If the symbol exists on Symvers we can decide whether the symbol must be
      * externalized or not, and not rely on ELF.

--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -538,9 +538,23 @@ public:
     PassName = "IbtTailGeneratePass";
   }
 
+  /* There are a few cases where we don't want IBT tail declarations to be
+   * defined:
+   * * If IBT is not enabled
+   * * If there are not externalized symbols
+   * * If all the externalized symbols are weak
+   */
   virtual bool Gate(PassManager::Context *ctx)
   {
-    return ctx->Ibt && ctx->Externalize.size() > 0;
+    if (!ctx->Ibt || ctx->Externalize.size() == 0)
+      return false;
+
+    for (const ExternalizerLogEntry &entry : ctx->NamesLog) {
+      if (entry.Type == ExternalizationType::STRONG)
+        return true;
+    }
+
+    return false;
   }
 
   virtual bool Run_Pass(PassManager::Context *ctx)

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -101,8 +101,13 @@ struct SymbolUpdateStatus
   }
 
   /* For IBT, NewDecl and OldDecl are the same if the symbols is a function, so
-     don't replace text if the name didn't change. */
+     don't replace text if the name didn't change.
+     In the case of WEAK externalization NewDecl will also be empty, but in this
+     case we don't want a symbol rename. */
   inline bool Needs_Sym_Rename(void) {
+    if (ExtType == ExternalizationType::WEAK)
+      return false;
+
     if (NewDecl == nullptr)
       return true;
 

--- a/testsuite/linux/Modules.symvers
+++ b/testsuite/linux/Modules.symvers
@@ -1,1 +1,2 @@
-0x00000000	crc32c	lib/libcrc32c	EXPORT_SYMBOL	
+0x00000000	crc32c	lib/libcrc32c	EXPORT_SYMBOL
+0x00000000	bpf_prog_put	vmlinux	EXPORT_SYMBOL_GPL

--- a/testsuite/linux/weak-symbols.c
+++ b/testsuite/linux/weak-symbols.c
@@ -1,0 +1,16 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_SYMVERS_PATH=../testsuite/linux/Modules.symvers -DCE_RENAME_SYMBOLS -nostdinc -I../testsuite/linux -D__USE_IBT__ -D__KERNEL__" } */
+
+int bpf_prog_put(void);
+
+int bpf_prog_put(void)
+{
+	return 42;
+}
+
+int f(void)
+{
+	return bpf_prog_put();
+}
+
+/* { dg-final { scan-tree-dump "int bpf_prog_put\(void\);" } } */
+/* { dg-final { scan-tree-dump-not "return 42;" } } */


### PR DESCRIPTION
Until this point all symbols found in kernel mode (usually using Symvers file), were strong (with externalized variables) or none (which copied the symbols to the closure). Now clang-extract checks is the symbol is present on vmlinux, meaning that the symbol is weak externalized, meaning the the symbol will be always present.