### PR TITLE
Disable Precompiled Headers

### DIFF
--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -79,7 +79,7 @@ static bool Build_ASTUnit(PassManager::Context *ctx, IntrusiveRefCntPtr<vfs::Fil
   PCHContainerOps = std::make_shared<PCHContainerOperations>();
 
   auto AU = ASTUnit::LoadFromCompilerInvocation(
-      CInvok, PCHContainerOps, Diags, FileMgr, false, CaptureDiagsKind::None, 1,
+      CInvok, PCHContainerOps, Diags, FileMgr, false, CaptureDiagsKind::None, 0,
       TU_Complete, false, false, false);
 
   if (AU == nullptr) {

--- a/testsuite/includes/pch-1.c
+++ b/testsuite/includes/pch-1.c
@@ -1,0 +1,13 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=main -DCE_NO_EXTERNALIZATION" }*/
+
+#include "pch-1.h"
+
+DEFINE_FUNCTION;
+
+int main()
+{
+  function_0();
+  return 0;
+}
+
+/* { dg-final { scan-tree-dump "function_0" } } */

--- a/testsuite/includes/pch-1.h
+++ b/testsuite/includes/pch-1.h
@@ -1,0 +1,12 @@
+#define __DEFINE_FUNCTION(i) \
+  int function_ ## i (void) { \
+    return 0;\
+  }
+
+#define _DEFINE_FUNCTION(i) \
+  __DEFINE_FUNCTION(i)
+
+#define DEFINE_FUNCTION \
+  _DEFINE_FUNCTION(__COUNTER__)
+
+DEFINE_FUNCTION;


### PR DESCRIPTION
Clang provides a feature to speedup header parsing which consists of generating a PrecompiledHeader (.pch) file to avoid having to compile the header multiple times if the main file needs to be reparsed multiple times, which is the case we are interested.

However, there seems to be a bug there because the Preprocessor is re-instantiated after generating them, loosing the __COUNT__ counter value. So we disable it until this issue is fixed.

After testing PCH enabled vs. disabled, I noticed clang-extract is significantly *faster* if PCH is disabled, hence disable it once for all (1.6s vs. 1.0s for vmwgfx_execbuf case).

Closes #8 