### PR TITLE
libcextract: ArgvParser: Disable Wduplicate-decl-specifier error

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -115,6 +115,9 @@ void ArgvParser::Insert_Required_Parameters(void)
     "-Wno-unused-function", // May happen when trying to extract a static function.
     "-Wno-unused-variable", // Passes may instroduce unused variables later removed.
     "-fno-builtin", // clang interposes some glibc functions and then it fails to find the declaration of them.
+    "-Wno-duplicate-decl-specifier", // Disabled due to kernel issues. See more
+                                     // at https://github.com/ClangBuiltLinux/linux/issues/2013
+                                     // and https://github.com/llvm/llvm-project/issues/93449
   };
 
   for (const char *arg : priv_args) {


### PR DESCRIPTION
This happens on recent kernel tree due to issues with LLVM. As we don't need any backends and only need to parse the source code we can disable the warning and move on.

For more information about the issue take a look into https://github.com/ClangBuiltLinux/linux/issues/2013 and https://github.com/llvm/llvm-project/issues/93449.