### PR TITLE
Fix CompleteDefinition of struct being dragged into output because of union fields

### DIFF
--- a/libcextract/Closure.hh
+++ b/libcextract/Closure.hh
@@ -140,7 +140,10 @@ class DeclClosureVisitor : public RecursiveASTVisitor<DeclClosureVisitor>
   public:
   DeclClosureVisitor(ASTUnit *ast)
     : RecursiveASTVisitor(),
-      AST(ast)
+      AST(ast),
+      Closure(),
+      AnalyzedDecls(),
+      Stack()
   {
   }
 
@@ -273,4 +276,14 @@ class DeclClosureVisitor : public RecursiveASTVisitor<DeclClosureVisitor>
 
   /** The set of all analyzed Decls.  */
   std::unordered_set<Decl *> AnalyzedDecls;
+
+  /** Stack of Decls.  Implement using a vector because we may need to access
+      the second element on the top, and we also need its continuity.  */
+  llvm::SmallVector<Decl *, 128> Stack;
+
+  /** Return what is on top of our stack.  */
+  inline Decl *Stack_Top(void)
+  {
+    return Stack[Stack.size() - 1];
+  }
 };

--- a/testsuite/small/record-nested-5.c
+++ b/testsuite/small/record-nested-5.c
@@ -1,0 +1,20 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+struct ll;
+
+int get(struct ll *);
+
+struct ll {
+  union {
+    unsigned long key;
+    void *key_ptr;
+  };
+  struct ll *next;
+};
+
+int f(struct ll *l)
+{
+  return get(l);
+}
+
+/* { dg-final { scan-tree-dump-not "struct ll *{" } } */


### PR DESCRIPTION
On the following example:
```
struct ll {
  union {
    unsigned long key;
    void *key_ptr;
  };
  struct ll *next;
};
```
Even if we don't need the full definition of `ll` it is dragged into the output because when analyzing this `union` field it tries to go up and set `struct ll` as having its body necessary once there was no way for it to know that it went there as a consequence of adding `struct ll` to the closure, rather than it being there because of a foward union declaration inside a struct.  This commit fixes this by pushing the Decls into a stack as a way to know which declarations we are currently analyzing.