### PR TITLE
Remove redundant decls

### DIFF
--- a/libcextract/LLVMMisc.cpp
+++ b/libcextract/LLVMMisc.cpp
@@ -281,3 +281,18 @@ DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const StringRef &name
 
   return Get_Decl_From_Symtab(ast, info->getValue());
 }
+
+/** Check if two Decls are equivalent.  */
+bool Is_Decl_Equivalent_To(Decl *a, Decl *b)
+{
+  std::string a_str;
+  std::string b_str;
+
+  llvm::raw_string_ostream a_stream(a_str);
+  llvm::raw_string_ostream b_stream(b_str);
+
+  a->print(a_stream);
+  b->print(b_stream);
+
+  return a_str == b_str;
+}

--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -100,3 +100,6 @@ DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const IdentifierInfo 
 
 /** Lookup in the symbol table for a declaration with given name passed by name.  */
 DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const StringRef &name);
+
+/** Check if two Decls are equivalent.  */
+bool Is_Decl_Equivalent_To(Decl *a, Decl *b);

--- a/testsuite/small/redundant-1.c
+++ b/testsuite/small/redundant-1.c
@@ -1,0 +1,16 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+struct ll;
+
+struct ll;
+
+int get(struct ll *);
+
+struct ll;
+
+int f(struct ll *l)
+{
+  return get(l);
+}
+
+/* { dg-final { scan-tree-dump-not "struct ll;\n+int get\(struct ll \*\);" } } */


### PR DESCRIPTION
Pass through the closure set looking for Decls we can erase. For example:
```
struct ll;

struct ll;

int get(struct ll *);

struct ll;
```
We just need the first `struct ll;`