### PR TITLE
Workaround ';' being output at incorrect location when decl ends with `#endif`

### DIFF
--- a/testsuite/small/attr-14.c
+++ b/testsuite/small/attr-14.c
@@ -1,0 +1,17 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+struct iwl_mvm_reorder_buf_entry {
+  int frames;
+}
+#ifndef __CHECKER__
+/* sparse doesn't like this construct: "bad integer constant expression" */
+__attribute__((aligned(32)))
+#endif
+;
+
+int f(struct iwl_mvm_reorder_buf_entry x)
+{
+  return x.frames;
+}
+
+/* { dg-final { scan-tree-dump "__attribute__\(\(aligned\(32\)\)\)" } } */


### PR DESCRIPTION
Workarounds this bizarre corner case found in iwlwifi kernel module.

Closes #115 