### PR TITLE
libcextract: ArgvParser: Use basename instead of std::filename

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -19,7 +19,11 @@
 
 #include <clang/Basic/Version.h>
 
-#include <filesystem>
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+/* Use the basename version that doesn't change the input string */
+#include <string.h>
 
 #ifndef CLANG_VERSION_MAJOR
 # error "Unable to find clang version"
@@ -89,7 +93,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
    * are not the same, it means that the module from PatchObject is builtin, so
    * assign vmlinux to PatchObject. */
   if (Kernel && DebuginfoPath) {
-    std::string obj_path = std::filesystem::path(DebuginfoPath).filename();
+    std::string obj_path = basename(DebuginfoPath);
     /* As the DebugInfo can point to a file with suffix (btrfs.ko for example),
      * check the substring */
     if (obj_path.find(PatchObject) == std::string::npos)


### PR DESCRIPTION
std::filename is not present on clang17, so it's easier to use basename so we are covered.