### PR TITLE
Fix externalization on Userpsace Livepatching

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -74,7 +74,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
     Ibt(false),
     AllowLateExternalization(false),
     PatchObject(""),
-    DebuginfoPath(nullptr),
+    Debuginfos(),
     IpaclonesPath(nullptr),
     SymversPath(nullptr),
     DescOutputPath(nullptr),
@@ -88,6 +88,11 @@ ArgvParser::ArgvParser(int argc, char **argv)
   }
 
   Insert_Required_Parameters();
+
+  const char *DebuginfoPath = nullptr;
+  if (Debuginfos.size() > 0) {
+    DebuginfoPath = Debuginfos[0].c_str();
+  }
 
   /* For kernel, check if the object patch is not the same as DebugInfo. If they
    * are not the same, it means that the module from PatchObject is builtin, so
@@ -252,7 +257,7 @@ bool ArgvParser::Handle_Clang_Extract_Arg(const char *str)
     return true;
   }
   if (prefix("-DCE_DEBUGINFO_PATH=", str)) {
-    DebuginfoPath = Extract_Single_Arg_C(str);
+    Debuginfos = Extract_Args(str);
 
     return true;
   }

--- a/libcextract/ArgvParser.hh
+++ b/libcextract/ArgvParser.hh
@@ -94,9 +94,9 @@ class ArgvParser
       return PatchObject;
   }
 
-  inline const char *Get_Debuginfo_Path(void)
+  inline std::vector<std::string> &Get_Debuginfo_Path(void)
   {
-    return DebuginfoPath;
+    return Debuginfos;
   }
 
   inline const char *Get_Ipaclones_Path(void)
@@ -163,7 +163,8 @@ class ArgvParser
   bool AllowLateExternalization;
   std::string PatchObject;
 
-  const char *DebuginfoPath;
+  std::vector<std::string> Debuginfos;
+
   const char *IpaclonesPath;
   const char *SymversPath;
 

--- a/libcextract/ElfCXX.cpp
+++ b/libcextract/ElfCXX.cpp
@@ -335,19 +335,30 @@ void ElfSymbolCache::Insert_Symbols_Into_Hash(SymbolTableHash &map, ElfSection &
 }
 
 ElfSymbolCache::ElfSymbolCache(ElfObject &eo)
-  : EO(eo)
+  : ElfSymbolCache()
+{
+  Analyze_ELF(eo);
+}
+
+void ElfSymbolCache::Analyze_ELF(ElfObject &eo)
 {
   /* Look for dynsym and symtab sections.  */
-  for (auto it = EO.section_begin(); it != EO.section_end(); ++it)
+  for (auto it = eo.section_begin(); it != eo.section_end(); ++it)
   {
     ElfSection &section = *it;
     switch (section.Get_Section_Type()) {
       case SHT_DYNSYM:
         Insert_Symbols_Into_Hash(DynsymMap, section);
+
+        assert(ObjectPath == "" && "Multiple libraries passed as debuginfo?");
+        ObjectPath = eo.Get_Path();
         break;
 
       case SHT_SYMTAB:
         Insert_Symbols_Into_Hash(SymtabMap, section);
+
+        /* We can also have symtab in the .so library.  */
+        DebuginfoPath = eo.Get_Path();
         break;
 
       case SHT_PROGBITS:

--- a/libcextract/ElfCXX.cpp
+++ b/libcextract/ElfCXX.cpp
@@ -365,6 +365,30 @@ ElfSymbolCache::ElfSymbolCache(ElfObject &eo)
   }
 }
 
+/** Get symbol if available in either symtab.  Returns in which symtab this
+    symbol was found.  */
+std::pair<unsigned char, ElfSymtabType>
+ElfSymbolCache::Get_Symbol_Info(const std::string &sym)
+{
+  unsigned char ret = 0;
+
+  /* Try the dynsym first, which means this symbol is most likely public
+     visible.  */
+  ret = Get_Symbol_Info_Dynsym(sym);
+  if (ret != 0) {
+    return std::make_pair(ret, ElfSymtabType::DYNSYM);
+  }
+
+  /* Symbol not available on dynsym.  Try symtab.  */
+  ret = Get_Symbol_Info_Symtab(sym);
+  if (ret != 0) {
+    return std::make_pair(ret, ElfSymtabType::SYMTAB);
+  }
+
+  /* If symbol is not here there is nothing I can do.  */
+  return std::make_pair(0, ElfSymtabType::TAB_NONE);
+}
+
 std::vector<std::string> ElfSymbolCache::Get_All_Symbols(void)
 {
   std::vector<std::string> vec;

--- a/libcextract/ElfCXX.hh
+++ b/libcextract/ElfCXX.hh
@@ -38,6 +38,14 @@ class ElfObject;
 class ElfSection;
 class ElfSymbol;
 
+
+/** The symbol table in which this symbol was found.  */
+enum ElfSymtabType {
+  TAB_NONE = 0,
+  SYMTAB = SHT_SYMTAB,
+  DYNSYM = SHT_DYNSYM,
+};
+
 /** @brief ELF symbol.
   *
   * An ELF executable may contain multiple symbols (variables, functions, ...).
@@ -357,6 +365,10 @@ class ElfSymbolCache
     }
     return 0;
   }
+
+  /** Get symbol if available in either symtab.  Returns in which symtab this
+      symbo was found.  */
+  std::pair<unsigned char, ElfSymtabType> Get_Symbol_Info(const std::string &sym);
 
   std::string Get_Symbol_Module(const std::string &)
   {

--- a/libcextract/ElfCXX.hh
+++ b/libcextract/ElfCXX.hh
@@ -346,6 +346,18 @@ class ElfSymbolCache
   /** Build cache from ElfObject).  */
   ElfSymbolCache(ElfObject &eo);
 
+  /** Build empty cache to be filled later.  */
+  ElfSymbolCache(void)
+    : DynsymMap(),
+      SymtabMap(),
+      Mod(""),
+      DebuginfoPath(""),
+      ObjectPath("")
+  {};
+
+  /** Analyze ELF object.  */
+  void Analyze_ELF(ElfObject &eo);
+
   /* Get symbol if available in the Dynsym table.  Or 0 if not available.  */
   inline unsigned char Get_Symbol_Info_Dynsym(const std::string &sym)
   {
@@ -377,6 +389,16 @@ class ElfSymbolCache
 
   std::vector<std::string> Get_All_Symbols(void);
 
+  inline const std::string &Get_Debuginfo_Path(void) const
+  {
+    return DebuginfoPath;
+  }
+
+  inline const std::string &Get_Object_Path(void) const
+  {
+    return ObjectPath;
+  }
+
   /** Dump for debugging reasons.  */
   void Dump_Cache(void);
 
@@ -394,6 +416,9 @@ class ElfSymbolCache
   /** Kernel module name, if .modinfo section is present. */
   std::string Mod;
 
-  /** Reference to the ElfObject used to build this object.  */
-  ElfObject &EO;
+  /** Path to the debuginfo object (contains .symtab section).  */
+  std::string DebuginfoPath;
+
+  /** Path to the .so file object (contains .dynsym section).  */
+  std::string ObjectPath;
 };

--- a/libcextract/InlineAnalysis.hh
+++ b/libcextract/InlineAnalysis.hh
@@ -74,7 +74,9 @@ class InlineAnalysis
                                       const char *output_path);
 
   /** Get the ELF info of a symbol.  */
-  unsigned char Get_Symbol_Info(const std::string &sym);
+
+  std::pair<unsigned char, ElfSymtabType>
+  Get_Symbol_Info(const std::string &sym);
 
   ExternalizationType Needs_Externalization(const std::string &sym);
 

--- a/libcextract/Passes.hh
+++ b/libcextract/Passes.hh
@@ -58,7 +58,7 @@ class PassManager {
             PatchObject(args.Get_PatchObject()),
             HeadersToExpand(args.Get_Headers_To_Expand()),
             ClangArgs(args.Get_Args_To_Clang()),
-            DebuginfoPath(args.Get_Debuginfo_Path()),
+            Debuginfos(args.Get_Debuginfo_Path()),
             IpaclonesPath(args.Get_Ipaclones_Path()),
             SymversPath(args.Get_Symvers_Path()),
             DscOutputPath(args.Get_Dsc_Output_Path()),
@@ -67,7 +67,7 @@ class PassManager {
                                args.Get_Include_Expansion_Policy(), Kernel)),
             NamesLog(),
             PassNum(0),
-            IA(DebuginfoPath, IpaclonesPath, SymversPath, args.Is_Kernel())
+            IA(Debuginfos, IpaclonesPath, SymversPath, args.Is_Kernel())
         {
         }
 
@@ -121,7 +121,7 @@ class PassManager {
         std::vector<const char *> &ClangArgs;
 
         /* Path to Debuginfo, if exists.  */
-        const char *DebuginfoPath;
+        std::vector<std::string> &Debuginfos;
 
         /* Path to Ipaclones, if exists.  */
         const char *IpaclonesPath;

--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -632,6 +632,10 @@ VarDecl *SymbolExternalizer::Create_Externalized_Var(DeclaratorDecl *decl, const
     sc
   );
 
+  if (!Ibt) {
+    ret->addAttr(UsedAttr::Create(astctx));
+  }
+
   /* return node.  */
   return ret;
 }

--- a/testsuite/ccp/ext-obj-5.c
+++ b/testsuite/ccp/ext-obj-5.c
@@ -12,5 +12,5 @@ void pu_f(void)
         ee_o;
 }
 
-/* { dg-final { scan-tree-dump "static char \(\*klpe_ee_o\)\[4\];" } } */
+/* { dg-final { scan-tree-dump "static char \(\*klpe_ee_o\)\[4\] __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "char s\[sizeof\(\(\*klpe_ee_o\)\)\], t\[sizeof\(\(\*klpe_ee_o\)\)\]\[sizeof\(\(\*klpe_ee_o\)\)\];" } } */

--- a/testsuite/includes/rewrite-1.c
+++ b/testsuite/includes/rewrite-1.c
@@ -7,6 +7,6 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */
 /* { dg-final { scan-tree-dump-not "#include \"header-1.h\"" } } */

--- a/testsuite/includes/rewrite-2.c
+++ b/testsuite/includes/rewrite-2.c
@@ -7,6 +7,6 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */
 /* { dg-final { scan-tree-dump-not "#include \"header-1.h\"" } } */

--- a/testsuite/includes/rewrite-4.c
+++ b/testsuite/includes/rewrite-4.c
@@ -5,5 +5,5 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */

--- a/testsuite/inline/inlined-into-1.c
+++ b/testsuite/inline/inlined-into-1.c
@@ -1,4 +1,4 @@
-/* { dg-compile "-fdump-ipa-clones -O3 -g3"} */
+/* { dg-compile "-fdump-ipa-clones -O3 -g3 -shared"} */
 /* { dg-options "-where-is-inlined g"} */
 
 static inline int g(void)
@@ -6,17 +6,24 @@ static inline int g(void)
   return 42;
 }
 
-int f()
+static __attribute__((noinline)) h(void)
 {
   return g();
 }
 
+int f()
+{
+  return h() + g();
+}
+
 int main(void)
 {
-  return f();
+  return f() + g();
 }
 
 
 /* { dg-final { scan-tree-dump "f" } } */
 /* { dg-final { scan-tree-dump "g" } } */
-/* { dg-final { scan-tree-dump "FUNC\tPublic" } } */
+/* { dg-final { scan-tree-dump "f *.*FUNC\tPublic symbol\n" } } */
+/* { dg-final { scan-tree-dump "h *.*FUNC\tPrivate symbol\n" } } */
+/* { dg-final { scan-tree-dump "main *.*FUNC\tPublic symbol\n" } } */

--- a/testsuite/lateext/lateext-2.c
+++ b/testsuite/lateext/lateext-2.c
@@ -10,5 +10,5 @@ int h(void)
 }
 
 /* { dg-final { scan-tree-dump "#define MACRO\n#include \"lateext-2.h\"\n#undef MACRO\n#include \"lateext-2.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\) \+ g\(\);" } } */

--- a/testsuite/lateext/lateext-3.c
+++ b/testsuite/lateext/lateext-3.c
@@ -7,5 +7,5 @@ int f(void)
   return inline_func();
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_var;" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_var __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump-not "#include \"lateext-3.h\"" } } */

--- a/testsuite/lateext/lateext-4.c
+++ b/testsuite/lateext/lateext-4.c
@@ -10,5 +10,5 @@ MACRO f(void)
 }
 
 /* { dg-final { scan-tree-dump "#include \"lateext-4.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-5.c
+++ b/testsuite/lateext/lateext-5.c
@@ -10,5 +10,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump "#include \"lateext-4.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-6.c
+++ b/testsuite/lateext/lateext-6.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "int g\(void\)" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-7.c
+++ b/testsuite/lateext/lateext-7.c
@@ -10,4 +10,4 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "DEFINE_STATIC_KEY_FALSE\(\*klpe_aaa\)" } } */
-/* { dg-final { scan-tree-dump "static struct AA \*klpe_aaa;" } } */
+/* { dg-final { scan-tree-dump "static struct AA \*klpe_aaa __attribute__\(\(used\)\);" } } */

--- a/testsuite/lateext/location-1.c
+++ b/testsuite/lateext/location-1.c
@@ -7,5 +7,5 @@ int f(void)
   return global;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_global;" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_global __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "clang-extract: from .*location-1.h:29:1" } } */

--- a/testsuite/small/rename-10.c
+++ b/testsuite/small/rename-10.c
@@ -8,5 +8,5 @@ int g()
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-12.c
+++ b/testsuite/small/rename-12.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "static int g" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "int klpp_f\(void\)\n{\n *return \(\*klpe_g\)\(\)" } } */

--- a/testsuite/small/rename-15.c
+++ b/testsuite/small/rename-15.c
@@ -18,4 +18,4 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(3\);" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(int\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(int\) __attribute__\(\(used\)\);" } } */

--- a/testsuite/small/rename-2.c
+++ b/testsuite/small/rename-2.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "static int g" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "int f\(void\)\n{\n *return \(\*klpe_g\)\(\)" } } */

--- a/testsuite/small/rename-3.c
+++ b/testsuite/small/rename-3.c
@@ -7,5 +7,5 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*\*klpe_f\)\(void\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "int g\(void\)\n{\n *return \(\*klpe_f\)\(\)" } } */

--- a/testsuite/small/rename-4.c
+++ b/testsuite/small/rename-4.c
@@ -12,5 +12,5 @@ int g()
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-5.c
+++ b/testsuite/small/rename-5.c
@@ -1,5 +1,5 @@
 /* { dg-options "-DCE_EXTRACT_FUNCTIONS=g -DCE_EXPORT_SYMBOLS=f" }*/
 #include "rename-5.h"
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-6.c
+++ b/testsuite/small/rename-6.c
@@ -11,6 +11,6 @@ int g()
   return a;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_a;" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_a __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_a\) = x;" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_a\);" } } */

--- a/testsuite/small/rename-8.c
+++ b/testsuite/small/rename-8.c
@@ -10,6 +10,6 @@ int f()
   return A + B ;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_bbb;" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_bbb __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "#define A \(\*klpe_bbb\)" } } */
 /* { dg-final { scan-tree-dump "#define B \(\*klpe_bbb\)" } } */

--- a/testsuite/small/rename-9.c
+++ b/testsuite/small/rename-9.c
@@ -10,5 +10,5 @@ int f()
   return OPENSSL_strdup("aaa");
 }
 
-/* { dg-final { scan-tree-dump "static char \(\*klpe_CRYPTO_strdup\)\(const char \*, const char \*, int\);" } } */
+/* { dg-final { scan-tree-dump "static char \(\*klpe_CRYPTO_strdup\)\(const char \*, const char \*, int\) __attribute__\(\(used\)\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_CRYPTO_strdup\)\(str," } } */


### PR DESCRIPTION
This PR contains multiple fixes with regard to symbol externalization for what concerns Userspace Livepathing. As follows:

- Every strong externalized function/variable now contains the attribute `used` to avoid gcc to remove the variable read on assembly (i.e. inlining the pointer to always be `NULL`). This most likely also affects kernel livepatching and possibly it went unnoticed so far because of the gcc version they are currently using. [Here is an example of this happening for function `f`, while `g` is correct](https://godbolt.org/z/9vYTvvz14).
- Fix symbol visibility if it is only available on `.symtab` section. `dlsym` won't be able to find such symbols, hence they should be strongly externalized rather than weakly.
- Allow clang-extract to be feed with two DEBUGINFO files: one is the real `*.debug` file which is found in `-debug` packages in SUSE Linux, the other is the `*.so` file.  This should not affect kernel livepatching, as they use another mechanism to decide symbol visibility.