### PR TITLE
libcextract: Passes: Adjust KLP_RELOC_SYMBOL_POS format

### DIFF
--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -574,7 +574,7 @@ public:
   {
     PrettyPrint::Print_Raw(
                 "#define KLP_RELOC_SYMBOL_POS(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME, SYM_POS) \\\n"
-                "\tasm(\"\\\".klp.sym.rela.\" #LP_OBJ_NAME \".\" #SYM_OBJ_NAME \".\" #SYM_NAME \",\" #SYM_POS \"\\\"\")\n"
+                "\tasm(\"\\\".klp.sym.rela.\" #LP_OBJ_NAME \".\" #SYM_OBJ_NAME \".\" #SYM_NAME \".\" #SYM_POS \"\\\"\")\n"
                 "#define KLP_RELOC_SYMBOL(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME) \\\n"
                 "\tKLP_RELOC_SYMBOL_POS(LP_OBJ_NAME, SYM_OBJ_NAME, SYM_NAME, 0)\n\n");
 


### PR DESCRIPTION
This was changed on linux kernel mailing list due to possible problems on binutils. For more information take a look here[1];

[1]: https://lore.kernel.org/all/ZljceDZ7eqEJtYhQ@redhat.com/