### PR TITLE
SymbolExternalizer: Add ! to TOKEN_VECTOR

### DIFF
--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -36,7 +36,7 @@
 
 /* Tokenize away the function-like macro stuff or expression, we only want
    the identifier.  */
-#define TOKEN_VECTOR " ().,;+-*/^|&{}[]<>^&|\r\n\t"
+#define TOKEN_VECTOR " ().,;+-*/^|&{}[]<>^&|!\r\n\t"
 
 /* Return the ranges for all identifiers on the ids vector */
 template <typename T>


### PR DESCRIPTION
Otherwise it doesn't recognize the following expression:

	if (unlikely(!check_prev_ino(leaf, key, slot, prev_key)))

Closes: #129