### PR TITLE
Allow clang-extract to ignore errors pointed by clang

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Clang-extract support many options which controls the output code:
 - `-DCE_SYMVERS_PATH=<arg>`       Path to kernel Modules.symvers file.  Only used when `-D__KERNEL__` is specified.
 - `-DCE_DSC_OUTPUT=<arg>`         Libpulp .dsc file output, used for userspace livepatching.
 - `-DCE_LATE_EXTERNALIZE`         Enable late externalization (declare externalized variables later than the original).  May reduce code output when `-DCE_KEEP_INCLUDES` is enabled.
+- `-DCE_IGNORE_CLANG_ERRORS`      Ignore clang compilation errors in a hope that code is generated even if it won't compile.
 
 For more switches, see
 ```

--- a/libcextract/ASTUnitHack.cpp
+++ b/libcextract/ASTUnitHack.cpp
@@ -1,0 +1,50 @@
+//===- ASTUnitHack.cpp - Hacks for the ASTUnit class ------------------*- C++ *-===//
+//
+// This project is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// \file
+/// Hacks for the ASTUnit class.
+//
+//===----------------------------------------------------------------------===//
+
+/* Author: Giuliano Belinassi  */
+
+#include <clang/Frontend/ASTUnit.h>
+#include <clang/Frontend/CompilerInvocation.h>
+#include <clang/Serialization/InMemoryModuleCache.h>
+
+using namespace clang;
+
+/** Filesystem that will be used in our custom ASTUnit::create, so that way we
+  * don't break clang's API.
+  */
+IntrusiveRefCntPtr<llvm::vfs::FileSystem> _Hack_VFS;
+
+/** Hack to create an ASTUnit from LoadFromCompilerInvocationAction with a
+ *  virtual filesystem.  That way we can use FrontendActions hooks when
+ *  creating the ASTUnit.
+ */
+std::unique_ptr<ASTUnit>
+ASTUnit::create(std::shared_ptr<CompilerInvocation> CI,
+                IntrusiveRefCntPtr<DiagnosticsEngine> Diags,
+                CaptureDiagsKind CaptureDiagnostics,
+                bool UserFilesAreVolatile) {
+
+  std::unique_ptr<ASTUnit> AST(new ASTUnit(false));
+  ConfigureDiags(Diags, *AST, CaptureDiagnostics);
+
+  AST->Diagnostics = Diags;
+  AST->FileSystemOpts = CI->getFileSystemOpts();
+  AST->Invocation = std::move(CI);
+  AST->FileMgr = new FileManager(AST->FileSystemOpts, _Hack_VFS);
+  AST->UserFilesAreVolatile = UserFilesAreVolatile;
+  AST->SourceMgr = new SourceManager(AST->getDiagnostics(), *AST->FileMgr,
+                                     UserFilesAreVolatile);
+  AST->ModuleCache = new InMemoryModuleCache;
+
+  return AST;
+}

--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -66,6 +66,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
     SymbolsToExternalize(),
     HeadersToExpand(),
     OutputFile(),
+    IgnoreClangErrors(false),
     DisableExternalization(false),
     WithIncludes(false),
     DumpPasses(false),
@@ -177,6 +178,8 @@ void ArgvParser::Print_Usage_Message(void)
 "  -DCE_LATE_EXTERNALIZE    Enable late externalization (declare externalized variables\n"
 "                           later than the original).  May reduce code output when\n"
 "                           -DCE_KEEP_INCLUDES is enabled\n"
+"  -DCE_IGNORE_CLANG_ERRORS Ignore clang compilation errors in a hope that code is\n"
+"                           generated even if it won't compile.\n"
 "\n";
 
   llvm::outs() << "The following arguments are ignored by clang-extract:\n";
@@ -288,6 +291,11 @@ bool ArgvParser::Handle_Clang_Extract_Arg(const char *str)
   }
   if (!strcmp("-DCE_LATE_EXTERNALIZE", str)) {
     AllowLateExternalization = true;
+
+    return true;
+  }
+  if (!strcmp("-DCE_IGNORE_CLANG_ERRORS", str)) {
+    IgnoreClangErrors = true;
 
     return true;
   }

--- a/libcextract/ArgvParser.hh
+++ b/libcextract/ArgvParser.hh
@@ -134,6 +134,11 @@ class ArgvParser
     return AllowLateExternalization;
   }
 
+  inline bool Get_Ignore_Clang_Errors(void)
+  {
+    return IgnoreClangErrors;
+  }
+
   const char *Get_Input_File(void);
 
   /** Print help usage message.  */
@@ -150,6 +155,7 @@ class ArgvParser
   std::vector<std::string> HeadersToExpand;
   std::string OutputFile;
 
+  bool IgnoreClangErrors;
   bool DisableExternalization;
   bool WithIncludes;
   bool DumpPasses;

--- a/libcextract/Passes.hh
+++ b/libcextract/Passes.hh
@@ -48,6 +48,7 @@ class PassManager {
           : FuncExtractNames(args.Get_Functions_To_Extract()),
             Externalize(args.Get_Symbols_To_Externalize()),
             OutputFile(args.Get_Output_File()),
+            IgnoreClangErrors(args.Get_Ignore_Clang_Errors()),
             ExternalizationDisabled(args.Is_Externalization_Disabled()),
             KeepIncludes(args.Should_Keep_Includes()),
             DumpPasses(args.Should_Dump_Passes()),
@@ -89,6 +90,9 @@ class PassManager {
 
         /** The final output file name.  */
         std::string &OutputFile;
+
+        /** Should we ignore compilation errors from clang?  */
+        bool IgnoreClangErrors;
 
         /** Is the externalization passes disabled?  */
         bool ExternalizationDisabled;

--- a/libcextract/meson.build
+++ b/libcextract/meson.build
@@ -33,7 +33,8 @@ libcextract_sources = [
   'TopLevelASTIterator.cpp',
   'ExpansionPolicy.cpp',
   'HeaderGenerate.cpp',
-  'Closure.cpp'
+  'Closure.cpp',
+  'ASTUnitHack.cpp'
 ]
 
 libcextract_static = static_library('cextract', libcextract_sources)

--- a/testsuite/small/ignore-errors.c
+++ b/testsuite/small/ignore-errors.c
@@ -1,0 +1,9 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION -DCE_IGNORE_CLANG_ERRORS" }*/
+
+void f(void)
+{
+  return 3;
+}
+
+/* { dg-final { scan-tree-dump "void f" } } */
+/* { dg-final { scan-tree-dump "return 3;" } } */


### PR DESCRIPTION
Sometime it is useful to not halt compilation if an error occurred because the generated code may still be useful when creating livepatches.  Hence add a new option:
```
-DCE_IGNORE_CLANG_ERRORS
```

To ignore clang errors and continue compilation even so.