### PR TITLE
Add support to llvm-19

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -15,7 +15,7 @@ jobs:
         opensuse: [tumbleweed]
         compiler: [clang]
         build-type: [debug, release]
-        version: [17, 18]
+        version: [17, 18, 19]
 
     container:
       image: opensuse/${{ matrix.opensuse }}

--- a/libcextract/IncludeTree.cpp
+++ b/libcextract/IncludeTree.cpp
@@ -192,7 +192,7 @@ void IncludeTree::Build_Header_Map(void)
 
     /* For Files.  */
     OptionalFileEntryRef file = node->Get_FileEntry();
-    const FileEntry *fentry = &file->getFileEntry();
+    const FileEntryRef fentry = *file;
     if (Map.find(fentry) != Map.end()) {
       /* FIXME: Find a way to correcly map the FileEntry to the node instead of
          discarding future appearances.  */
@@ -526,8 +526,9 @@ bool IncludeNode::Is_Reachable_From_Main(void)
                                         nullptr);
 
   if (ref.has_value()) {
-    const FileEntry &entry = (*ref).getFileEntry();
-    if (Tree.IEP->Must_Expand(entry.tryGetRealPathName(), entry.getName())) {
+    const FileEntryRef &entry = *ref;
+    const FileEntry &fentry = ref->getFileEntry();
+    if (Tree.IEP->Must_Expand(fentry.tryGetRealPathName(), entry.getName())) {
       /* Lie telling it is unreachable, which would force an expansion.  */
       return false;
     }

--- a/libcextract/MacroWalker.cpp
+++ b/libcextract/MacroWalker.cpp
@@ -98,7 +98,7 @@ bool MacroWalker::Is_Identifier_Macro_Argument(MacroInfo *info, StringRef tok_st
 {
   for (const IdentifierInfo *arg : info->params()) {
     StringRef arg_str = arg->getName();
-    if (tok_str.equals(arg_str)) {
+    if (tok_str == arg_str) {
       return true;
     }
   }

--- a/libcextract/PrettyPrint.cpp
+++ b/libcextract/PrettyPrint.cpp
@@ -125,7 +125,7 @@ void PrettyPrint::Print_Decl_Raw(Decl *decl)
     /* If for some reason Get_Source_Text is unable to find the source range
        which comes this declaration because it is very complex, then fall back
        to AST dump.  */
-    if (decl_source.equals("")) {
+    if (decl_source == "") {
       /* TODO: warn user that we had to fallback to AST dump.  */
 
       if (TypedefNameDecl *typedecl = dyn_cast<TypedefNameDecl>(decl)) {

--- a/libcextract/SymbolExternalizer.hh
+++ b/libcextract/SymbolExternalizer.hh
@@ -225,7 +225,10 @@ class TextModifications
   void Commit(void);
 
   /* Get FileEntry map.  */
-  inline const std::unordered_map<const FileEntry *, FileID> &Get_FileEntry_Map(void)
+  typedef std::unordered_map<const FileEntry *, std::pair<FileID, StringRef>>
+    FileEntryMapType;
+
+  inline const FileEntryMapType &Get_FileEntry_Map(void)
   {
     return FileEntryMap;
   }
@@ -272,7 +275,7 @@ class TextModifications
 
   /* Our own mapping from FileEntry to FileID to get the modifications to the
      files.  */
-  std::unordered_map<const FileEntry *, FileID> FileEntryMap;
+  FileEntryMapType FileEntryMap;
 };
 
 /** Class encapsulating the Symbol externalizer mechanism.

--- a/testsuite/ccp/ext-obj-5.c
+++ b/testsuite/ccp/ext-obj-5.c
@@ -12,5 +12,5 @@ void pu_f(void)
         ee_o;
 }
 
-/* { dg-final { scan-tree-dump "static char \(\*klpe_ee_o\)\[4\] __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static char \(\*klpe_ee_o\)\[4\] __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static char \(\*klpe_ee_o\)\[4\];" } } */
 /* { dg-final { scan-tree-dump "char s\[sizeof\(\(\*klpe_ee_o\)\)\], t\[sizeof\(\(\*klpe_ee_o\)\)\]\[sizeof\(\(\*klpe_ee_o\)\)\];" } } */

--- a/testsuite/includes/rewrite-1.c
+++ b/testsuite/includes/rewrite-1.c
@@ -7,6 +7,6 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */
 /* { dg-final { scan-tree-dump-not "#include \"header-1.h\"" } } */

--- a/testsuite/includes/rewrite-2.c
+++ b/testsuite/includes/rewrite-2.c
@@ -7,6 +7,6 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */
 /* { dg-final { scan-tree-dump-not "#include \"header-1.h\"" } } */

--- a/testsuite/includes/rewrite-4.c
+++ b/testsuite/includes/rewrite-4.c
@@ -5,5 +5,5 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_f\)\(\)" } } */

--- a/testsuite/lateext/lateext-2.c
+++ b/testsuite/lateext/lateext-2.c
@@ -10,5 +10,5 @@ int h(void)
 }
 
 /* { dg-final { scan-tree-dump "#define MACRO\n#include \"lateext-2.h\"\n#undef MACRO\n#include \"lateext-2.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\) \+ g\(\);" } } */

--- a/testsuite/lateext/lateext-3.c
+++ b/testsuite/lateext/lateext-3.c
@@ -7,5 +7,5 @@ int f(void)
   return inline_func();
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_var __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_var __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \*klpe_var;" } } */
 /* { dg-final { scan-tree-dump-not "#include \"lateext-3.h\"" } } */

--- a/testsuite/lateext/lateext-4.c
+++ b/testsuite/lateext/lateext-4.c
@@ -10,5 +10,5 @@ MACRO f(void)
 }
 
 /* { dg-final { scan-tree-dump "#include \"lateext-4.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-5.c
+++ b/testsuite/lateext/lateext-5.c
@@ -10,5 +10,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump "#include \"lateext-4.h\"" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-6.c
+++ b/testsuite/lateext/lateext-6.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "int g\(void\)" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(\);" } } */

--- a/testsuite/lateext/lateext-7.c
+++ b/testsuite/lateext/lateext-7.c
@@ -10,4 +10,4 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "DEFINE_STATIC_KEY_FALSE\(\*klpe_aaa\)" } } */
-/* { dg-final { scan-tree-dump "static struct AA \*klpe_aaa __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static struct AA \*klpe_aaa __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static struct AA \*klpe_aaa;" } } */

--- a/testsuite/lateext/location-1.c
+++ b/testsuite/lateext/location-1.c
@@ -7,5 +7,5 @@ int f(void)
   return global;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_global __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_global __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \*klpe_global;" } } */
 /* { dg-final { scan-tree-dump "clang-extract: from .*location-1.h:29:1" } } */

--- a/testsuite/small/rename-10.c
+++ b/testsuite/small/rename-10.c
@@ -8,5 +8,5 @@ int g()
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-12.c
+++ b/testsuite/small/rename-12.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "static int g" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(\);" } } */
 /* { dg-final { scan-tree-dump "int klpp_f\(void\)\n{\n *return \(\*klpe_g\)\(\)" } } */

--- a/testsuite/small/rename-15.c
+++ b/testsuite/small/rename-15.c
@@ -18,4 +18,4 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump "return \(\*klpe_g\)\(3\);" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(int\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(int\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(int\);" } } */

--- a/testsuite/small/rename-2.c
+++ b/testsuite/small/rename-2.c
@@ -11,5 +11,5 @@ int f(void)
 }
 
 /* { dg-final { scan-tree-dump-not "static int g" } } */
-/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_g\)\(\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_g\)\(\);" } } */
 /* { dg-final { scan-tree-dump "int f\(void\)\n{\n *return \(\*klpe_g\)\(\)" } } */

--- a/testsuite/small/rename-3.c
+++ b/testsuite/small/rename-3.c
@@ -7,5 +7,5 @@ int g(void)
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*\*klpe_f\)\(void\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*\*klpe_f\)\(void\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*\*klpe_f\)\(void\);" } } */
 /* { dg-final { scan-tree-dump "int g\(void\)\n{\n *return \(\*klpe_f\)\(\)" } } */

--- a/testsuite/small/rename-4.c
+++ b/testsuite/small/rename-4.c
@@ -12,5 +12,5 @@ int g()
   return f();
 }
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(\)" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-5.c
+++ b/testsuite/small/rename-5.c
@@ -1,5 +1,5 @@
 /* { dg-options "-DCE_EXTRACT_FUNCTIONS=g -DCE_EXPORT_SYMBOLS=f" }*/
 #include "rename-5.h"
 
-/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \(\*klpe_f\)\(\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \(\*klpe_f\)\(\);" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_f\)\(\);" } } */

--- a/testsuite/small/rename-6.c
+++ b/testsuite/small/rename-6.c
@@ -11,6 +11,6 @@ int g()
   return a;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_a __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_a __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \*klpe_a" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_a\) = x;" } } */
 /* { dg-final { scan-tree-dump "return \(\*klpe_a\);" } } */

--- a/testsuite/small/rename-8.c
+++ b/testsuite/small/rename-8.c
@@ -10,6 +10,6 @@ int f()
   return A + B ;
 }
 
-/* { dg-final { scan-tree-dump "static int \*klpe_bbb __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static int \*klpe_bbb __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static int \*klpe_bbb;" } } */
 /* { dg-final { scan-tree-dump "#define A \(\*klpe_bbb\)" } } */
 /* { dg-final { scan-tree-dump "#define B \(\*klpe_bbb\)" } } */

--- a/testsuite/small/rename-9.c
+++ b/testsuite/small/rename-9.c
@@ -10,5 +10,5 @@ int f()
   return OPENSSL_strdup("aaa");
 }
 
-/* { dg-final { scan-tree-dump "static char \(\*klpe_CRYPTO_strdup\)\(const char \*, const char \*, int\) __attribute__\(\(used\)\);" } } */
+/* { dg-final { scan-tree-dump "static char \(\*klpe_CRYPTO_strdup\)\(const char \*, const char \*, int\) __attribute__\(\(used\)\);|__attribute__\(\(used\)\) static char \(\*klpe_CRYPTO_strdup\)\(const char \*, const char \*, int\);" } } */
 /* { dg-final { scan-tree-dump "\(\*klpe_CRYPTO_strdup\)\(str," } } */


### PR DESCRIPTION
This commit updates the codebase so that it compiles with llvm-19.

- Replaces uses of FileEntry::getName() with FileEntryRef::getName().
- Update the __attribute__((used)) location on the tests.