### PR TITLE
Add compatibility to llvm-20

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -15,7 +15,7 @@ jobs:
         opensuse: [tumbleweed]
         compiler: [clang]
         build-type: [debug, release]
-        version: [17, 18, 19]
+        version: [18, 19, 20]
 
     container:
       image: opensuse/${{ matrix.opensuse }}

--- a/libcextract/ClangCompat.hh
+++ b/libcextract/ClangCompat.hh
@@ -102,4 +102,15 @@ namespace ClangCompat
     return A;
 #endif
   }
+
+  static inline IntrusiveRefCntPtr<DiagnosticsEngine> createDiagnostics(
+                llvm::vfs::FileSystem &VFS,
+                DiagnosticOptions *Opts)
+  {
+#if CLANG_VERSION_MAJOR >= 20
+    return CompilerInstance::createDiagnostics(VFS, Opts);
+#else
+    return CompilerInstance::createDiagnostics(Opts);
+#endif
+  }
 }

--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -79,7 +79,7 @@ static bool Build_ASTUnit(PassManager::Context *ctx, IntrusiveRefCntPtr<vfs::Fil
     diagopts->ShowColors = true;
   }
 
-  Diags = CompilerInstance::createDiagnostics(diagopts);
+  Diags = ClangCompat::createDiagnostics(*_Hack_VFS, diagopts);
 
   if (ctx->IgnoreClangErrors) {
     Diags->setWarningsAsErrors(false);


### PR DESCRIPTION
The function `CompilerInstance::createDiagnostics()` changed its signature in llvm-20, hence we need to check the llvm version and adjust the call properly.

This also adds llvm-20 to the CI.