### PR TITLE
Fix ce-inline crashing when no debuginfo is provided

### DIFF
--- a/libcextract/InlineAnalysis.hh
+++ b/libcextract/InlineAnalysis.hh
@@ -54,7 +54,9 @@ class InlineAnalysis
 
   InlineAnalysis(const char *elf_path, const char *ipaclone_path,
                  const char *symvers_path, bool is_kernel)
-    : InlineAnalysis(std::vector<std::string>({elf_path}),
+    : InlineAnalysis(elf_path == nullptr ?
+                     std::vector<std::string>() :
+                     std::vector<std::string>({elf_path}),
                      ipaclone_path, symvers_path, is_kernel)
   {}
 


### PR DESCRIPTION
Previously, if ce-inline were called without providing a debuginfo (elf_path) to it, the program would crash as result of attempting to build a string from nullptr.  This is because when elf_path is null, the resulting vector should be empty.