### PR TITLE
Add new expansion policies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,17 @@ Notice how *any reference to unused_function is removed* and *all headers has be
 $ clang out.c -O2 -o a
 ```
 If you desire to keep the includes, see `-DCE_KEEP_INCLUDES` options and the _Supported options_ chapter.
+The following expansion policies are supported:
+ - `nothing`: Do not expand any header.
+ - `everything`: Expand all headers.  Has the same semantic effect of not passing `-DCE_KEEP_INCLUDES`, but forces clang-extract to pass it through its header expansion logics (slow and very likely buggy!).
+ - `kernel`: Special policy used by the kernel livepatching developers.
+ - `system`: Keep all system headers installed in `/usr/include`, etc.
+ - `compiler`: Keep all compiler-specific headers, such as `stdatomic.h`. Useful if you want to expand everything but still want to ensure compatibility with other compilers.
+
+You may want to use `clang-tidy` to cleanup the generated file afterwards to remove duplicated includes:
+```
+$ clang-tidy -checks='-*,readability-duplicate-include,misc-include-cleaner' -fix <out.c>
+```
 
 ### Symbol Externalization
 
@@ -192,7 +203,7 @@ Clang-extract support many options which controls the output code:
 - `-DCE_NO_EXTERNALIZATION`       Disable symbol externalization.
 - `-DCE_DUMP_PASSES`              Dump the results of each transformation pass into files. Files will be dumped at the same path of the input files. Additional files are also generated on `/tmp/` folder.
 - `-DCE_KEEP_INCLUDES`            Keep all possible `#include<file>` directives.
-- `-DCE_KEEP_INCLUDES=<policy>`   Keep all possible `#include<file>` directives, but using the specified include expansion <policy>.  Valid values are nothing, everything and kernel.
+- `-DCE_KEEP_INCLUDES=<policy>`   Keep all possible `#include<file>` directives, but using the specified include expansion <policy>.  Valid values are `nothing`, `everything`, `kernel`, `system` and `compiler`.
 - `-DCE_EXPAND_INCLUDES=<args>`   Force expansion of the headers provided in <args>.
 - `-DCE_RENAME_SYMBOLS`           Allow renaming of extracted symbols.
 - `-DCE_DEBUGINFO_PATH=<arg>`     Path to the compiled (ELF) object of the desired program to extract.  This is used to decide if externalization is necessary or not for given symbol.

--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -157,7 +157,7 @@ void ArgvParser::Print_Usage_Message(void)
 "  -DCE_KEEP_INCLUDES=<policy>\n"
 "                           Keep all possible #include<file> directives, but using the\n"
 "                           specified include expansion <policy>.  Valid values are\n"
-"                           nothing, everything and kernel.\n"
+"                           nothing, everything, kernel, system and compiler.\n"
 "  -DCE_EXPAND_INCLUDES=<args>\n"
 "                           Force expansion of the headers provided in <args>.\n"
 "  -DCE_RENAME_SYMBOLS      Allow renaming of extracted symbols.\n"

--- a/libcextract/ExpansionPolicy.hh
+++ b/libcextract/ExpansionPolicy.hh
@@ -32,6 +32,8 @@ class IncludeExpansionPolicy
     NOTHING,
     EVERYTHING,
     KERNEL,
+    SYSTEM,
+    COMPILER,
   };
 
   static IncludeExpansionPolicy *Get_Expansion_Policy(Policy policy);
@@ -75,7 +77,22 @@ class ExpandEverythingExpansionPolicy : public IncludeExpansionPolicy
   }
 };
 
+/** Expand any header according to kernel livepatching rules.  */
 class KernelExpansionPolicy : public IncludeExpansionPolicy
+{
+  public:
+  virtual bool Must_Expand(const StringRef &absolute_path, const StringRef &relative_path);
+};
+
+/** Expand any header that is not installed in the system.  */
+class SystemExpansionPolicy : public IncludeExpansionPolicy
+{
+  public:
+  virtual bool Must_Expand(const StringRef &absolute_path, const StringRef &relative_path);
+};
+
+/** Expand any header that is not compiler-specific.  */
+class CompilerExpansionPolicy : public IncludeExpansionPolicy
 {
   public:
   virtual bool Must_Expand(const StringRef &absolute_path, const StringRef &relative_path);

--- a/testsuite/includes/policy-compiler-1.c
+++ b/testsuite/includes/policy-compiler-1.c
@@ -1,0 +1,19 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=fn_c -DCE_NO_EXTERNALIZATION -DCE_KEEP_INCLUDES=compiler" }*/
+
+#include <stdio.h>
+#include <stdatomic.h>
+#include <pthread.h>
+
+atomic_int cnt_atomic;
+
+void* fn_c(void *thr_data) {
+  (void)thr_data;
+  for (int i = 0; i < 40000; i++) {
+    atomic_fetch_add(&cnt_atomic, 1);
+  }
+  return NULL;
+}
+
+/* { dg-final { scan-tree-dump-not "#include <stdio.h>" } } */
+/* { dg-final { scan-tree-dump "#include <stdatomic.h>" } } */
+/* { dg-final { scan-tree-dump "#include <stddef.h>" } } */

--- a/testsuite/includes/policy-system-1.c
+++ b/testsuite/includes/policy-system-1.c
@@ -1,0 +1,21 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=fn_c -DCE_NO_EXTERNALIZATION -DCE_KEEP_INCLUDES=system" }*/
+
+#include <stdio.h>
+#include <stdatomic.h>
+#include <pthread.h>
+#include "header-1.h"
+
+atomic_int cnt_atomic;
+
+void* fn_c(void *thr_data) {
+  (void)thr_data;
+  for (int i = 0; i < 40000; i++) {
+    atomic_fetch_add(&cnt_atomic, 1);
+  }
+  return NULL;
+}
+
+/* { dg-final { scan-tree-dump "#include <stdio.h>" } } */
+/* { dg-final { scan-tree-dump "#include <stdatomic.h>" } } */
+/* { dg-final { scan-tree-dump "#include <pthread.h>" } } */
+/* { dg-final { scan-tree-dump-not "#include \"header-1.h\"" } } */


### PR DESCRIPTION
This commit add two new expansion policies:

- system: keep includes from system headers, such as stdio.h, stdlib.h, and other libraries that may be installed in the system.

- compiler: keep compiler-specific includes, such as stdatomic.h, stddef.h, and other includes that may expand into compiler-specific code.

Use `-DCE_KEEP_INCLUDES=<policy>` to use them.

Closes #139