### PR TITLE
Fix ArrayRef constructor ambiguity on 32-bit systems

### DIFF
--- a/libcextract/LLVMMisc.cpp
+++ b/libcextract/LLVMMisc.cpp
@@ -233,7 +233,7 @@ ArrayRef<Decl *> Get_Toplev_Decls_With_Same_Beginloc(ASTUnit *ast, const SourceL
     }
   }
 
-  return ArrayRef<Decl *>(nullptr, 0UL);
+  return ArrayRef<Decl *>(nullptr, size_t(0));
 }
 
 std::string Build_CE_Location_Comment(SourceManager &sm, const SourceLocation &loc)


### PR DESCRIPTION
Fixes the following build error on 32bit systems:
```
[12:53:45] libcextract/LLVMMisc.cpp: In function ‘llvm::ArrayRef<clang::Decl*> Get_Toplev_Decls_With_Same_Beginloc(clang::ASTUnit*, const clang::SourceLocation&)’:
[12:53:45] libcextract/LLVMMisc.cpp:236:39: error: call of overloaded ‘ArrayRef(std::nullptr_t, long unsigned int)’ is ambiguous
[12:53:45]   236 |   return ArrayRef<Decl *>(nullptr, 0UL);
[12:53:45]       |                                       ^
[12:53:45] In file included from /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/llvm/Support/Format.h:25,
[12:53:45]                  from /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/llvm/Support/Error.h:24,
[12:53:45]                  from /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/llvm/Support/FileSystem.h:34,
[12:53:45]                  from /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/clang/Basic/FileManager.h:29,
[12:53:45]                  from /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/clang/Tooling/Tooling.h:33,
[12:53:45]                  from libcextract/LLVMMisc.hh:20,
[12:53:45]                  from libcextract/LLVMMisc.cpp:17:
[12:53:45] /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/llvm/ADT/ArrayRef.h:82:15: note: candidate: ‘constexpr llvm::ArrayRef<T>::ArrayRef(const T*, const T*) [with T = clang::Decl*]’
[12:53:45]    82 |     constexpr ArrayRef(const T *begin LLVM_LIFETIME_BOUND, const T *end)
[12:53:45]       |               ^~~~~~~~
[12:53:45] /opt/i686-linux-gnu/bin/../i686-linux-gnu/sys-root/usr/local/include/llvm/ADT/ArrayRef.h:77:28: note: candidate: ‘constexpr llvm::ArrayRef<T>::ArrayRef(const T*, size_t) [with T = clang::Decl*; size_t = unsigned int]’
[12:53:45]    77 |     constexpr /*implicit*/ ArrayRef(const T *data LLVM_LIFETIME_BOUND,
[12:53:45]       |                            ^~~~~~~~
```