### PR TITLE
Make sure we get a matching number of #if and #endifs before copying …

### DIFF
--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -109,3 +109,6 @@ DeclContextLookupResult Get_Decl_From_Symtab(ASTUnit *ast, const StringRef &name
 
 /** Check if two Decls are equivalent.  */
 bool Is_Decl_Equivalent_To(Decl *a, Decl *b);
+
+/** Check if string has unmatched #if, #ifdef, #ifndef.  */
+bool Has_Balanced_Ifdef(const StringRef &string);

--- a/testsuite/small/ifdef-1.c
+++ b/testsuite/small/ifdef-1.c
@@ -1,7 +1,4 @@
 /* { dg-options "-DCE_EXTRACT_FUNCTIONS=function -DCE_NO_EXTERNALIZATION" }*/
-/* { dg-xfail } Tests fails because we currently can't track that the endif
-   comes from #ifdef AAA.  */
-
 
 //#define AA
 

--- a/testsuite/small/ifdef-2.c
+++ b/testsuite/small/ifdef-2.c
@@ -1,0 +1,30 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_NO_EXTERNALIZATION" }*/
+
+#define SHARED
+
+#define IS_IN(x) 0
+
+#ifndef SHARED
+# define GLRO(name) _##name
+#else
+# if IS_IN (rtld)
+#  define GLRO(name) _rtld_local_ro._##name
+# else
+#  define GLRO(name) _rtld_global_ro._##name
+# endif
+struct rtld_global_ro
+{
+#endif
+  int field1;
+#ifdef SHARED
+  int field2;
+};
+#endif
+
+
+int f(struct rtld_global_ro *r)
+{
+  return r->field1;
+}
+
+/* { dg-final { scan-tree-dump "struct rtld_global_ro ?\n?{" } } */


### PR DESCRIPTION
…function to output

glibc has some weird cornercases in `sysdeps/generic/ldsodefs.h` where a struct definition depends of a macro definition (SHARED), but its fields attributes does not.  Here we devise an heuristic to try to detect such cases by looking if the number of #ifs and #endifs matches in the function.  If not, then fallback to AST dumping.

Closes #147