### PR TITLE
Remove any use of `basename`

### DIFF
--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -19,12 +19,6 @@
 
 #include <clang/Basic/Version.h>
 
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
-/* Use the basename version that doesn't change the input string */
-#include <string.h>
-
 #ifndef CLANG_VERSION_MAJOR
 # error "Unable to find clang version"
 #endif
@@ -101,7 +95,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
    * are not the same, it means that the module from PatchObject is builtin, so
    * assign vmlinux to PatchObject. */
   if (Kernel && DebuginfoPath) {
-    std::string obj_path = basename(DebuginfoPath);
+    std::string obj_path = get_basename(DebuginfoPath);
     /* As the DebugInfo can point to a file with suffix (btrfs.ko for example),
      * check the substring */
     if (obj_path.find(PatchObject) == std::string::npos)

--- a/libcextract/NonLLVMMisc.cpp
+++ b/libcextract/NonLLVMMisc.cpp
@@ -140,3 +140,15 @@ enum FileHandling::FileType FileHandling::Get_File_Type(int fd)
 
   return FILE_TYPE_UNKNOWN;
 }
+
+/** Get basename of a string.  Works like the gnu version.  */
+const char *get_basename(const char *filename)
+{
+#if defined(_WIN32) || defined(WIN32)
+  const char delim = '\\';
+#else
+  const char delim = '/';
+#endif
+  const char *p = strrchr (filename, delim);
+  return p ? p + 1 : (char *) filename;
+}

--- a/libcextract/NonLLVMMisc.hh
+++ b/libcextract/NonLLVMMisc.hh
@@ -91,3 +91,6 @@ class FileHandling
 
   static enum FileType Get_File_Type(int fd);
 };
+
+/** Get basename of a string.  Works like the gnu version.  */
+const char *get_basename(const char *filename);

--- a/libcextract/SymversParser.cpp
+++ b/libcextract/SymversParser.cpp
@@ -21,6 +21,8 @@
 #include <sstream>
 #include <libgen.h>
 
+#include "NonLLVMMisc.hh"
+
 Symvers::Symvers(const std::string &path)
     : Parser(path)
 {
@@ -64,7 +66,7 @@ void Symvers::Parse()
     std::getline(ss, sym_mod, '\t');
 
     // Only get the name of the module, instead of the path to it
-    Symbol sym(sym_name, basename(sym_mod.data()));
+    Symbol sym(sym_name, get_basename(sym_mod.data()));
     Insert_Symbols_Into_Hash(sym);
   }
 }


### PR DESCRIPTION
The function `basename` has 2 versions, one strdup the input string and the other one just returns a pointer to the original string.  The one which is being used is not clear in the program and we were using both of them in this project, hence get rid of it entirely and provide our own.

Fixes #144 