### PR TITLE
Properly handle win32 paths in `get_basename`

### DIFF
--- a/libcextract/NonLLVMMisc.cpp
+++ b/libcextract/NonLLVMMisc.cpp
@@ -142,13 +142,13 @@ enum FileHandling::FileType FileHandling::Get_File_Type(int fd)
 }
 
 /** Get basename of a string.  Works like the gnu version.  */
-const char *get_basename(const char *filename)
+const char *get_basename(const char *path)
 {
-#if defined(_WIN32) || defined(WIN32)
-  const char delim = '\\';
-#else
-  const char delim = '/';
+  const char *base = strrchr(path, '/');
+#ifdef _WIN32
+  const char *backslash = strrchr(path, '\\');
+  if (backslash > base)
+    base = backslash;
 #endif
-  const char *p = strrchr (filename, delim);
-  return p ? p + 1 : (char *) filename;
+  return base ? base+1 : path;
 }


### PR DESCRIPTION
Although we don't support Windows in clang-extract, someone in the future will probably thank us for having this already working.

Copied from:
https://github.com/JuliaLang/julia/blob/fa66b63fc3421fa549f901afeb88d34dc88d06fd/src/timing.h#L8-L17