### PR TITLE
Fix test failing if gcc is 7.5.0

### DIFF
--- a/testsuite/inline/inlined-into-1.c
+++ b/testsuite/inline/inlined-into-1.c
@@ -6,7 +6,7 @@ static inline int g(void)
   return 42;
 }
 
-static __attribute__((noipa)) h(void)
+static __attribute__((noipa)) __attribute__((noinline)) h(void)
 {
   return g();
 }

--- a/testsuite/lib/libtest.py
+++ b/testsuite/lib/libtest.py
@@ -406,7 +406,7 @@ class UnitTest:
         return r
 
     def check(self, tool, ce_output_path):
-        self.log.print("terminal output of inline:")
+        self.log.print("terminal output of " + os.path.basename(tool.args[0]) + ":")
         self.log.print(tool.stdout.decode())
 
         should_xfail = self.extract_should_xfail()


### PR DESCRIPTION
We expect that `h` is not inlined anywhere, so make sure it isn't.