### PR TITLE
Add warning about libpulp TLS support

### DIFF
--- a/libcextract/DscFileGenerator.cpp
+++ b/libcextract/DscFileGenerator.cpp
@@ -92,11 +92,6 @@ void DscFileGenerator::Global_Functions(void)
   }
 }
 
-static bool Is_TLS(VarDecl *decl)
-{
-  return decl->getTLSKind() == VarDecl::TLS_None ? false : true;
-}
-
 static bool Is_TLS(const DeclContext::lookup_result &decls)
 {
   bool is_tls = false;

--- a/libcextract/LLVMMisc.hh
+++ b/libcextract/LLVMMisc.hh
@@ -112,3 +112,10 @@ bool Is_Decl_Equivalent_To(Decl *a, Decl *b);
 
 /** Check if string has unmatched #if, #ifdef, #ifndef.  */
 bool Has_Balanced_Ifdef(const StringRef &string);
+
+
+/** Check if the VarDecl is declared as TLS.  */
+static inline bool Is_TLS(VarDecl *decl)
+{
+  return decl->getTLSKind() == VarDecl::TLS_None ? false : true;
+}

--- a/libcextract/SymbolExternalizer.cpp
+++ b/libcextract/SymbolExternalizer.cpp
@@ -650,6 +650,18 @@ VarDecl *SymbolExternalizer::Create_Externalized_Var(DeclaratorDecl *decl, const
      variable as well.  */
   if (VarDecl *vdecl = dyn_cast<VarDecl>(decl)) {
     ret->setTSCSpec(vdecl->getTSCSpec());
+
+    /* Libpulp support TLS through some ugly hacking.  Warn the user about it
+       for now.  */
+    if (Is_TLS(vdecl)) {
+      std::string msg = "Externalization of TLS variable " +
+                        vdecl->getName().str() +
+                        " requires human intervention to call __tls_get_addr";
+
+
+      DiagsClass::Emit_Warn(msg, vdecl->getSourceRange(),
+                            AST->getSourceManager());
+    }
   }
 
   /* return node.  */

--- a/testsuite/small/tls-2.c
+++ b/testsuite/small/tls-2.c
@@ -1,0 +1,12 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=set_errno -DCE_EXPORT_SYMBOLS=__libc_errno" }*/
+/* { dg-xfail }*/
+
+extern __thread int __libc_errno __attribute__ ((tls_model ("initial-exec")));
+
+void set_errno(int err)
+{
+  __libc_errno = err;
+}
+
+/* { dg-final { scan-tree-dump "__attribute__\(\(used\)\) static tls_index klpe___libc_errno_ti;" } } */
+/* { dg-final { scan-tree-dump "__tls_get_addr\(klpe___libc_errno_ti\)" } } */


### PR DESCRIPTION
TLS variables in libpulp needs to call __tls_get_addr manually, which certainly would require quite lot of code to properly support it in the SymbolExternalizer.  Therefore, add a warn message about the necessity of human intervention for that.