### PR TITLE
Correctly visit MemberExpr

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -30,6 +30,8 @@ jobs:
            llvm${{ matrix.version }}
            llvm${{ matrix.version }}-devel
            meson ninja clang-tools gcc findutils bash libelf-devel zlib-devel libzstd-devel
+    - name: check llvm-ar
+      run: if [ /usr/bin/llvm-ar ]; then ln -s /usr/bin/llvm-ar-${{ matrix.version }} /usr/bin/llvm-ar; fi
     - uses: actions/checkout@v2
     - name: meson
       run: meson setup build --buildtype=${{ matrix.build-type }} --native-file ce-native.ini

--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -62,6 +62,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
   : ArgsToClang(),
     FunctionsToExtract(),
     SymbolsToExternalize(),
+    SymbolsToNotExternalize(),
     HeadersToExpand(),
     HeadersToNotExpand(),
     OutputFile(),
@@ -104,6 +105,20 @@ ArgvParser::ArgvParser(int argc, char **argv)
     if (obj_path.find(PatchObject) == std::string::npos)
       PatchObject = "vmlinux";
   }
+
+  /* Check for contradictory options.  */
+  for (auto it = SymbolsToNotExternalize.begin();
+       it != SymbolsToNotExternalize.end(); it++) {
+    for (auto ij = SymbolsToExternalize.begin(); ij != SymbolsToExternalize.end(); ij++) {
+      if (*it == *ij) {
+        std::string message = "symbol " + *ij + " is marked for expansion and "
+                                                "not expansion at the same time!";
+        DiagsClass::Emit_Error(message);
+        exit(1);
+      }
+    }
+  }
+
 }
 
 void ArgvParser::Insert_Required_Parameters(void)
@@ -149,6 +164,8 @@ void ArgvParser::Print_Usage_Message(void)
 "                           Extract the functions specified in the <args> list.\n"
 "  -DCE_EXPORT_SYMBOLS=<args>\n"
 "                           Force externalization of symbols specified in the <args> list\n"
+"  -DCE_NOT_EXPORT_SYMBOLS=<args>\n"
+"                           Do not externalize symbols specified in the <args> list\n"
 "  -DCE_OUTPUT_FILE=<arg>   Output code to <arg> file.  Default is <input>.CE.c.\n"
 "  -DCE_NO_EXTERNALIZATION  Disable symbol externalization.\n"
 "  -DCE_DUMP_PASSES         Dump the results of each transformation pass into files.\n"
@@ -228,6 +245,11 @@ bool ArgvParser::Handle_Clang_Extract_Arg(const char *str)
   }
   if (prefix("-DCE_EXPORT_SYMBOLS=", str)) {
     SymbolsToExternalize = Extract_Args(str);
+
+    return true;
+  }
+  if (prefix("-DCE_NOT_EXPORT_SYMBOLS=", str)) {
+    SymbolsToNotExternalize = Extract_Args(str);
 
     return true;
   }

--- a/libcextract/ArgvParser.hh
+++ b/libcextract/ArgvParser.hh
@@ -54,6 +54,11 @@ class ArgvParser
     return SymbolsToExternalize;
   }
 
+  inline std::vector<std::string>& Get_Symbols_To_Not_Externalize(void)
+  {
+    return SymbolsToNotExternalize;
+  }
+
   inline std::vector<std::string>& Get_Headers_To_Expand(void)
   {
     return HeadersToExpand;
@@ -155,6 +160,7 @@ class ArgvParser
 
   std::vector<std::string> FunctionsToExtract;
   std::vector<std::string> SymbolsToExternalize;
+  std::vector<std::string> SymbolsToNotExternalize;
   std::vector<std::string> HeadersToExpand;
   std::vector<std::string> HeadersToNotExpand;
   std::string OutputFile;

--- a/libcextract/Closure.cpp
+++ b/libcextract/Closure.cpp
@@ -372,6 +372,27 @@ bool DeclClosureVisitor::VisitClassTemplateSpecializationDecl(
 
 /* ----------- Statements -------------- */
 
+bool DeclClosureVisitor::VisitMemberExpr(MemberExpr *expr)
+{
+  /* Make sure we grow the closure towards the RecordDecl that contains
+     the FieldDecl accessed by the MemberExpr,  for example, if clang see:
+
+     a->x;
+
+     it should grow the closure to include:
+
+     struct AA {
+      int x;
+     }  */
+
+  if (FieldDecl *field = dyn_cast<FieldDecl>(expr->getMemberDecl())) {
+    RecordDecl *record = field->getParent();
+    return TraverseDecl(record);
+  }
+
+  return VISITOR_CONTINUE;
+}
+
 bool DeclClosureVisitor::VisitDeclRefExpr(DeclRefExpr *expr)
 {
   TRY_TO(TraverseDecl(expr->getDecl()));

--- a/libcextract/Closure.hh
+++ b/libcextract/Closure.hh
@@ -214,6 +214,8 @@ class DeclClosureVisitor : public RecursiveASTVisitor<DeclClosureVisitor>
 
   /* ----------- Statements -------------- */
 
+  bool VisitMemberExpr(MemberExpr *expr);
+
   bool VisitDeclRefExpr(DeclRefExpr *expr);
 
   bool VisitOffsetOfExpr(OffsetOfExpr *expr);

--- a/libcextract/FunctionDepsFinder.cpp
+++ b/libcextract/FunctionDepsFinder.cpp
@@ -122,7 +122,7 @@ void FunctionDependencyFinder::Remove_Redundant_Decls(void)
               PrettyPrint::Get_Source_Text(type_range) != "") {
 
             /* Using .fullyContains() fails in some declarations.  */
-            if (PrettyPrint::Contains_From_LineCol(range, type_range)) {
+            if (PrettyPrint::Contains(range, type_range)) {
               closure.Remove_Decl(typedecl);
             }
           }

--- a/libcextract/NonLLVMMisc.hh
+++ b/libcextract/NonLLVMMisc.hh
@@ -58,6 +58,28 @@ void Remove_Duplicates(std::vector<T>& vec)
   vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 }
 
+template <typename T>
+bool Remove_Elements_Present_In_2nd_Vector(std::vector<T>& v1, const std::vector<T> &v2)
+{
+  bool ret = false;
+
+  if (v2.size() == 0)
+    return false;
+
+  /* Remove any element in to_externalize that is in NotExternalize.  */
+  for (auto it = v1.begin(); it != v1.end(); it++) {
+    for (auto ij = v2.begin(); ij != v2.end(); ij++) {
+      if (*it == *ij) {
+        v1.erase(it);
+        it--;
+        ret = true;
+      }
+    }
+  }
+
+  return ret;
+}
+
 /** Get a single line from a file, removing its newline.
   *
   * NOTE: if this function return a valid pointer, it must be free'd.

--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -535,11 +535,17 @@ class FunctionExternalizerPass : public Pass
                                       ctx->HeadersToExpand,
                                       ctx->HeadersToNotExpand,
                                       ctx->DumpPasses);
+
+      std::vector<std::string> to_externalize(ctx->Externalize);
+
+      /* Remove any element in to_externalize that is in NotExternalize.  */
+      Remove_Elements_Present_In_2nd_Vector(to_externalize, ctx->NotExternalize);
+
       if (ctx->RenameSymbols)
         /* The FuncExtractNames will be modified, as the function will be renamed.  */
-        externalizer.Externalize_Symbols(ctx->Externalize, ctx->FuncExtractNames);
+        externalizer.Externalize_Symbols(to_externalize, ctx->FuncExtractNames);
       else
-        externalizer.Externalize_Symbols(ctx->Externalize);
+        externalizer.Externalize_Symbols(to_externalize);
 
       externalizer.Commit_Changes_To_Source(ctx->OFS, ctx->MFS, ctx->HeadersToExpand);
 

--- a/libcextract/Passes.hh
+++ b/libcextract/Passes.hh
@@ -47,6 +47,7 @@ class PassManager {
         Context(ArgvParser &args)
           : FuncExtractNames(args.Get_Functions_To_Extract()),
             Externalize(args.Get_Symbols_To_Externalize()),
+            NotExternalize(args.Get_Symbols_To_Not_Externalize()),
             OutputFile(args.Get_Output_File()),
             IgnoreClangErrors(args.Get_Ignore_Clang_Errors()),
             ExternalizationDisabled(args.Is_Externalization_Disabled()),
@@ -88,6 +89,9 @@ class PassManager {
 
         /** List of functions to externalize.  */
         std::vector<std::string> &Externalize;
+
+        /** List of functions to not externalize.  */
+        std::vector<std::string> &NotExternalize;
 
         /** The final output file name.  */
         std::string &OutputFile;

--- a/testsuite/small/macro-23.c
+++ b/testsuite/small/macro-23.c
@@ -1,0 +1,103 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_EXPORT_SYMBOLS=OSSL_CMP_PROTECTEDPART_it" }*/
+/* { dg-xfail }*/
+
+# define DECLARE_ASN1_FUNCTIONS_attr(attr, type)                           \
+   DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_FUNCTIONS(type)                                      \
+   DECLARE_ASN1_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, name)                \
+   DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)                \
+   DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)
+
+# define DECLARE_ASN1_FUNCTIONS_attr(attr, type)                            \
+    DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_FUNCTIONS(type)                                       \
+    DECLARE_ASN1_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_attr(attr, type)                      \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_ALLOC_FUNCTIONS(type)                                 \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, name)                 \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)                \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)
+# define DECLARE_ASN1_FUNCTIONS_name(type, name)                            \
+    DECLARE_ASN1_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_attr(attr, type, itname, name)       \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(attr, type, name)               \
+    DECLARE_ASN1_ITEM_attr(attr, itname)
+# define DECLARE_ASN1_ENCODE_FUNCTIONS(type, itname, name)                  \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_attr(extern, type, itname, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)          \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_attr(attr, type, name, name)
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_name(type, name) \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(attr, type, name)          \
+    attr type *d2i_##name(type **a, const unsigned char **in, long len);    \
+    attr int i2d_##name(const type *a, unsigned char **out);
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_only(type, name)                     \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(extern, type, name)
+
+# define DECLARE_ASN1_NDEF_FUNCTION_attr(attr, name)                        \
+    attr int i2d_##name##_NDEF(const name *a, unsigned char **out);
+# define DECLARE_ASN1_NDEF_FUNCTION(name)                                   \
+    DECLARE_ASN1_NDEF_FUNCTION_attr(extern, name)
+
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)           \
+    attr type *name##_new(void);                                            \
+    attr void name##_free(type *a);
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_name(type, name)                      \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_DUP_FUNCTION_attr(attr, type)                         \
+    DECLARE_ASN1_DUP_FUNCTION_name_attr(attr, type, type)
+# define DECLARE_ASN1_DUP_FUNCTION(type)                                    \
+    DECLARE_ASN1_DUP_FUNCTION_attr(extern, type)
+
+# define DECLARE_ASN1_DUP_FUNCTION_name_attr(attr, type, name)              \
+    attr type *name##_dup(const type *a);
+# define DECLARE_ASN1_DUP_FUNCTION_name(type, name)                         \
+    DECLARE_ASN1_DUP_FUNCTION_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_PRINT_FUNCTION_attr(attr, stname)                     \
+    DECLARE_ASN1_PRINT_FUNCTION_fname_attr(attr, stname, stname)
+# define DECLARE_ASN1_PRINT_FUNCTION(stname)                                \
+    DECLARE_ASN1_PRINT_FUNCTION_attr(extern, stname)
+
+# define DECLARE_ASN1_PRINT_FUNCTION_fname_attr(attr, stname, fname)        \
+    attr int fname##_print_ctx(BIO *out, const stname *x, int indent,       \
+                               const ASN1_PCTX *pctx);
+# define DECLARE_ASN1_PRINT_FUNCTION_fname(stname, fname)                   \
+    DECLARE_ASN1_PRINT_FUNCTION_fname_attr(extern, stname, fname)
+
+# define DECLARE_ASN1_ITEM_attr(attr, name)                                 \
+    attr const ASN1_ITEM * name##_it(void);
+# define DECLARE_ASN1_ITEM(name)                                            \
+    DECLARE_ASN1_ITEM_attr(extern, name)
+
+
+#define ASN1_ITEM_rptr(ref) (ref##_it())
+
+typedef struct asn_item ASN1_ITEM;
+
+typedef struct pkiheader OSSL_CMP_PKIHEADER;
+typedef struct pkibody   OSSL_CMP_PKIBODY;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+    OSSL_CMP_PKIBODY *body;
+} OSSL_CMP_PROTECTEDPART;
+
+DECLARE_ASN1_FUNCTIONS(OSSL_CMP_PROTECTEDPART);
+
+void *f(void)
+{
+  return (void *) ASN1_ITEM_rptr(OSSL_CMP_PROTECTEDPART);
+}
+
+/* { dg-final { scan-tree-dump "\(\*klpe_OSSL_CMP_PROTECTEDPART_it\)\(\)" } } */

--- a/testsuite/small/record-13.c
+++ b/testsuite/small/record-13.c
@@ -1,0 +1,25 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=ossl_cmp_calc_protection -DCE_NO_EXTERNALIZATION" }*/
+
+typedef struct ossl_cmp_pkiheader_st OSSL_CMP_PKIHEADER;
+typedef struct ossl_cmp_msg_st OSSL_CMP_MSG;
+
+struct ossl_cmp_msg_st {
+    OSSL_CMP_PKIHEADER *header;
+};
+
+
+typedef struct ossl_cmp_ctx_st OSSL_CMP_CTX;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+} OSSL_CMP_PROTECTEDPART;
+
+void *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
+                                          const OSSL_CMP_MSG *msg)
+{
+    OSSL_CMP_PROTECTEDPART prot_part;
+    prot_part.header = msg->header;
+    return ((void*)0);
+}
+
+/* { dg-final { scan-tree-dump "struct ossl_cmp_msg_st {\n *OSSL_CMP_PKIHEADER \*header;" } } */

--- a/testsuite/small/record-14.c
+++ b/testsuite/small/record-14.c
@@ -1,0 +1,26 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=ossl_cmp_calc_protection -DCE_NO_EXTERNALIZATION" }*/
+
+typedef struct ossl_cmp_pkiheader_st OSSL_CMP_PKIHEADER;
+typedef struct ossl_cmp_msg_st OSSL_CMP_MSG;
+
+struct ossl_cmp_msg_st {
+    OSSL_CMP_PKIHEADER *header;
+};
+
+struct ossl_cmp_msg_st;
+
+typedef struct ossl_cmp_ctx_st OSSL_CMP_CTX;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+} OSSL_CMP_PROTECTEDPART;
+
+void *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
+                                          const OSSL_CMP_MSG *msg)
+{
+    OSSL_CMP_PROTECTEDPART prot_part;
+    prot_part.header = msg->header;
+    return ((void*)0);
+}
+
+/* { dg-final { scan-tree-dump "struct ossl_cmp_msg_st {\n *OSSL_CMP_PKIHEADER \*header;" } } */


### PR DESCRIPTION
For some reason MemberExpr weren't being correctly visited. Do it now.

Also add an option for clang-extract to forcefully not externalize given symbol.