### PR TITLE
Merge update IPA clones callgraph with information from the source code.

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -30,6 +30,8 @@ jobs:
            llvm${{ matrix.version }}
            llvm${{ matrix.version }}-devel
            meson ninja clang-tools gcc findutils bash libelf-devel zlib-devel libzstd-devel
+    - name: check llvm-ar
+      run: if [ /usr/bin/llvm-ar ]; then ln -s /usr/bin/llvm-ar-${{ matrix.version }} /usr/bin/llvm-ar; fi
     - uses: actions/checkout@v2
     - name: meson
       run: meson setup build --buildtype=${{ matrix.build-type }} --native-file ce-native.ini

--- a/Inline.cpp
+++ b/Inline.cpp
@@ -19,6 +19,10 @@
 #include <stdio.h>
 #include <vector>
 #include <string>
+#include <iostream>
+#include <fstream>
+
+#include <clang/Tooling/Tooling.h>
 
 enum MODE {
   LIST_ALL,
@@ -40,6 +44,7 @@ const char *Output_Path = nullptr;
 static const char *Elf_Path = nullptr;
 static const char *Ipa_Path = nullptr;
 static const char *Symvers_Path = nullptr;
+static const char *Source_Path = nullptr;
 
 static std::vector<std::string> Symbols_To_Analyze;
 
@@ -55,6 +60,7 @@ static void Print_Usage(void)
 "     -csv                     Output as a .csv table format,\n"
 "     -where-is-inlined        Find where <SYMBOLS> got inlined,\n"
 "     -compute-closure         Find symbols that got inlined into <SYMBOLS>,\n"
+"     -source    <PATH>        Input source file in <PATH>."
 "     -o         <PATH>        Output to file in <PATH>.\n"
   );
   exit(0);
@@ -88,6 +94,10 @@ static void Parse(int argc, char *argv[])
         continue;
       }
 
+      if (strcmp(argv[i], "-source") == 0) {
+        Source_Path = argv[++i];
+        continue;
+      }
     }
 
     if (strcmp(argv[i], "-graphviz") == 0) {
@@ -204,6 +214,15 @@ int main(int argc, char *argv[])
   try {
 
     InlineAnalysis ia(Elf_Path, Ipa_Path, Symvers_Path, false);
+
+    /* If we have source code then load it now.  */
+    if (Source_Path && ia.Have_IPA()) {
+      std::stringstream buffer;
+      buffer << std::ifstream(Source_Path).rdbuf();
+
+      ia.Update_With_Source_Code_Info(
+        clang::tooling::buildASTFromCode(buffer.str(), Source_Path).get());
+    }
 
     if (Mode == LIST_ALL) {
       std::set<std::string> set = ia.Get_All_Symbols();

--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -62,6 +62,7 @@ ArgvParser::ArgvParser(int argc, char **argv)
   : ArgsToClang(),
     FunctionsToExtract(),
     SymbolsToExternalize(),
+    SymbolsToNotExternalize(),
     HeadersToExpand(),
     HeadersToNotExpand(),
     OutputFile(),
@@ -104,6 +105,20 @@ ArgvParser::ArgvParser(int argc, char **argv)
     if (obj_path.find(PatchObject) == std::string::npos)
       PatchObject = "vmlinux";
   }
+
+  /* Check for contradictory options.  */
+  for (auto it = SymbolsToNotExternalize.begin();
+       it != SymbolsToNotExternalize.end(); it++) {
+    for (auto ij = SymbolsToExternalize.begin(); ij != SymbolsToExternalize.end(); ij++) {
+      if (*it == *ij) {
+        std::string message = "symbol " + *ij + " is marked for expansion and "
+                                                "not expansion at the same time!";
+        DiagsClass::Emit_Error(message);
+        exit(1);
+      }
+    }
+  }
+
 }
 
 void ArgvParser::Insert_Required_Parameters(void)
@@ -149,6 +164,8 @@ void ArgvParser::Print_Usage_Message(void)
 "                           Extract the functions specified in the <args> list.\n"
 "  -DCE_EXPORT_SYMBOLS=<args>\n"
 "                           Force externalization of symbols specified in the <args> list\n"
+"  -DCE_NOT_EXPORT_SYMBOLS=<args>\n"
+"                           Do not externalize symbols specified in the <args> list\n"
 "  -DCE_OUTPUT_FILE=<arg>   Output code to <arg> file.  Default is <input>.CE.c.\n"
 "  -DCE_NO_EXTERNALIZATION  Disable symbol externalization.\n"
 "  -DCE_DUMP_PASSES         Dump the results of each transformation pass into files.\n"
@@ -228,6 +245,11 @@ bool ArgvParser::Handle_Clang_Extract_Arg(const char *str)
   }
   if (prefix("-DCE_EXPORT_SYMBOLS=", str)) {
     SymbolsToExternalize = Extract_Args(str);
+
+    return true;
+  }
+  if (prefix("-DCE_NOT_EXPORT_SYMBOLS=", str)) {
+    SymbolsToNotExternalize = Extract_Args(str);
 
     return true;
   }

--- a/libcextract/ArgvParser.cpp
+++ b/libcextract/ArgvParser.cpp
@@ -142,6 +142,7 @@ void ArgvParser::Insert_Required_Parameters(void)
     "-Wno-duplicate-decl-specifier", // Disabled due to kernel issues. See more
                                      // at https://github.com/ClangBuiltLinux/linux/issues/2013
                                      // and https://github.com/llvm/llvm-project/issues/93449
+    "-Wno-unused-command-line-argument" // Disable warnings stating that '-c' is ignored.
   };
 
   for (const char *arg : priv_args) {

--- a/libcextract/ArgvParser.hh
+++ b/libcextract/ArgvParser.hh
@@ -54,6 +54,11 @@ class ArgvParser
     return SymbolsToExternalize;
   }
 
+  inline std::vector<std::string>& Get_Symbols_To_Not_Externalize(void)
+  {
+    return SymbolsToNotExternalize;
+  }
+
   inline std::vector<std::string>& Get_Headers_To_Expand(void)
   {
     return HeadersToExpand;
@@ -155,6 +160,7 @@ class ArgvParser
 
   std::vector<std::string> FunctionsToExtract;
   std::vector<std::string> SymbolsToExternalize;
+  std::vector<std::string> SymbolsToNotExternalize;
   std::vector<std::string> HeadersToExpand;
   std::vector<std::string> HeadersToNotExpand;
   std::string OutputFile;

--- a/libcextract/Closure.cpp
+++ b/libcextract/Closure.cpp
@@ -230,6 +230,33 @@ bool DeclClosureVisitor::VisitRecordDecl(RecordDecl *decl)
   TRY_TO(ParentRecordDeclHelper(decl));
 
   Closure.Add_Single_Decl(decl);
+
+
+  /* In case our RecordDecl was triggered to be in the closure, then also
+     analyse the types of any FieldDecl it contains. For example:
+
+      struct quic_channel_st {
+          SSL *tls;
+          BIO_ADDR cur_peer_addr;
+      };
+
+     if we are here because we accessed `tls` attribute of this struct, we also
+     need to make sure BIO_ADDR is also included in the closure, otherwise we
+     can't know the size of quic_channel_st even if nothing accesses it.  See
+     closure-7.c testcase for a case where this happens.
+
+     For some reason, sometimes the struct definition found by clang AST
+     visitor when comming from an TypedefType isn't the full definition of the
+     struct when we need it!  In this case, lets make sure we also process the
+     declaration that have the definition.  */
+  if (!decl->isCompleteDefinition()) {
+    RecordDecl *complete = decl->getDefinition();
+    if (complete != nullptr && complete != decl &&
+        complete->isCompleteDefinitionRequired()) {
+      TRY_TO(TraverseDecl(complete));
+    }
+  }
+
   /* Also analyze the previous version of this decl for any version of it
      that is nested-declared inside another record.  */
   TRY_TO(AnalyzePreviousDecls(decl));
@@ -288,7 +315,7 @@ bool DeclClosureVisitor::VisitEnumConstantDecl(EnumConstantDecl *decl)
   return VISITOR_CONTINUE;
 }
 
-/* Not called automatically by Transverse.  */
+/* Not called automatically by Traverse.  */
 bool DeclClosureVisitor::VisitTypedefNameDecl(TypedefNameDecl *decl)
 {
   // FIXME: Do we need to analyze the previous decls?

--- a/libcextract/Closure.cpp
+++ b/libcextract/Closure.cpp
@@ -372,6 +372,27 @@ bool DeclClosureVisitor::VisitClassTemplateSpecializationDecl(
 
 /* ----------- Statements -------------- */
 
+bool DeclClosureVisitor::VisitMemberExpr(MemberExpr *expr)
+{
+  /* Make sure we grow the closure towards the RecordDecl that contains
+     the FieldDecl accessed by the MemberExpr,  for example, if clang see:
+
+     a->x;
+
+     it should grow the closure to include:
+
+     struct AA {
+      int x;
+     }  */
+
+  if (FieldDecl *field = dyn_cast<FieldDecl>(expr->getMemberDecl())) {
+    RecordDecl *record = field->getParent();
+    return TraverseDecl(record);
+  }
+
+  return VISITOR_CONTINUE;
+}
+
 bool DeclClosureVisitor::VisitDeclRefExpr(DeclRefExpr *expr)
 {
   TRY_TO(TraverseDecl(expr->getDecl()));

--- a/libcextract/Closure.hh
+++ b/libcextract/Closure.hh
@@ -214,6 +214,8 @@ class DeclClosureVisitor : public RecursiveASTVisitor<DeclClosureVisitor>
 
   /* ----------- Statements -------------- */
 
+  bool VisitMemberExpr(MemberExpr *expr);
+
   bool VisitDeclRefExpr(DeclRefExpr *expr);
 
   bool VisitOffsetOfExpr(OffsetOfExpr *expr);

--- a/libcextract/FunctionDepsFinder.cpp
+++ b/libcextract/FunctionDepsFinder.cpp
@@ -122,7 +122,7 @@ void FunctionDependencyFinder::Remove_Redundant_Decls(void)
               PrettyPrint::Get_Source_Text(type_range) != "") {
 
             /* Using .fullyContains() fails in some declarations.  */
-            if (PrettyPrint::Contains_From_LineCol(range, type_range)) {
+            if (PrettyPrint::Contains(range, type_range)) {
               closure.Remove_Decl(typedecl);
             }
           }

--- a/libcextract/InlineAnalysis.cpp
+++ b/libcextract/InlineAnalysis.cpp
@@ -530,3 +530,103 @@ std::string InlineAnalysis::Get_Symbol_Module(std::string sym)
 
   return {};
 }
+
+#include "LLVMMisc.hh"
+#include "PrettyPrint.hh"
+
+using namespace clang;
+using namespace llvm;
+
+void InlineAnalysis::Update_With_Source_Code_Info(ASTUnit *ast)
+{
+  /* If we don't have the IPA clones then there is no point in updating its
+     information.  */
+  if (Ipa == nullptr)
+    return;
+
+  /* Get the lookup table.  */
+  TranslationUnitDecl *tu = ast->getASTContext().getTranslationUnitDecl();
+  DeclarationNameTable &decltbl = ast->getASTContext().DeclarationNames;
+  IdentifierTable &idtbl = ast->getPreprocessor().getIdentifierTable();
+
+  /* Build Callgraph.  */
+  CallGraph *cg = Build_CallGraph_From_AST(ast);
+  CallGraphNode *root = cg->getRoot();
+
+  /* Clang callgraph doesn't have information about callers, so...  */
+  DenseMap<CallGraphNode *, SmallVector<CallGraphNode *, 4>> callers;
+  for (auto it = cg->begin(); it != cg->end(); ++it) {
+    CallGraphNode *caller = it->second.get();
+
+    /* Ignore the virtual root object.  */
+    if (caller == root)
+      continue;
+
+    for (const auto &call_record : caller->callees()) {
+      CallGraphNode *callee = call_record.Callee;
+      callers[callee].push_back(caller);
+    }
+  }
+
+  /* We are potentially going to remove nodes.  Lets mark them to be removed
+     to avoid having to handle issues with the unordered_set iterator.  */
+  SmallVector<IpaCloneNode *, 8> to_remove;
+
+  /* Iterate on each node in the IPA clones graph.  This is not DFS!  */
+  for (auto it = Ipa->begin(); it != Ipa->end(); ++it) {
+    const std::string &name = it->first;
+    IpaCloneNode *node = &(it->second);
+
+    /* Strip away any postfix in the name that could have been a result of GCC
+       modifying the symbol.  */
+    std::string name_without_dot = name.substr(0, name.find('.'));
+
+    if (name == name_without_dot) {
+      /* This is not a custom function created by GCC, hence the IPA
+         clones info should be correct.  */
+
+      continue;
+    }
+
+    /* Get decls matching the name in the IpaClone node.  */
+    DeclContext::lookup_result decls = tu->lookup(decltbl.getIdentifier(
+                                                  &idtbl.get(name_without_dot)));
+
+    /* Iterate on them.  */
+    if (decls.empty()) {
+      throw std::runtime_error("Unable to find symbol " + name +
+                               " in the AST, but is in provided .ipaclone!");
+    }
+
+    /* Get original IPA clone node without the GCC quirks in its name.  */
+    IpaCloneNode *node_without_dot = Ipa->Get_Node(name_without_dot);
+
+    /* Merge this node with the original node.  */
+    Ipa->Merge_Nodes(node_without_dot, node);
+    to_remove.push_back(node);
+
+    for (NamedDecl *decl : decls) {
+      CallGraphNode *callee = cg->getNode(decl);
+
+      /* Update the IpaClones graph with this information.  */
+      for (CallGraphNode *caller : callers[callee]) {
+        NamedDecl *decl = dyn_cast<NamedDecl>(caller->getDecl());
+
+        assert(decl && "Decl in callgraph without a name?");
+
+        IpaCloneNode *ipa_caller = Ipa->Get_Or_Create_Node(decl->getNameAsString());
+        IpaCloneNode *ipa_callee = node_without_dot;
+
+        ipa_callee->InlinedInto.insert(ipa_caller);
+        ipa_caller->Inlines.insert(ipa_callee);
+      }
+    }
+  }
+
+  /* Remove nodes marked to be removed.  */
+  for (IpaCloneNode *node : to_remove)
+    Ipa->Remove_Node(node);
+
+  /* Destroy our callgraph.  */
+  delete cg;
+}

--- a/libcextract/InlineAnalysis.cpp
+++ b/libcextract/InlineAnalysis.cpp
@@ -161,18 +161,14 @@ static int Action_Graphviz(void *s, IpaCloneNode *n1, IpaCloneNode *n2)
 
 void InlineAnalysis::Print_Node_Colors(const std::set<IpaCloneNode *> &set, FILE *fp)
 {
-  if (!Have_Debuginfo()) {
-    return;
-  }
-
   for (IpaCloneNode *node : set) {
     const char *demangled = InlineAnalysis::Demangle_Symbol(node->Name.c_str());
     std::pair<unsigned char, ElfSymtabType> infos = Get_Symbol_Info(node->Name);
     unsigned char syminfo = infos.first;
     ElfSymtabType symtab = infos.second;
-    if (syminfo == 0) {
+    if (syminfo == 0 || node->Removed) {
       fprintf(fp, "\n\"%s\" [style=dotted]", demangled);
-    } else {
+    } else if (Have_Debuginfo()) {
       //unsigned char type = ElfSymbol::Type_Of(syminfo);
       unsigned char bind = ElfSymbol::Bind_Of(syminfo);
       if (bind == STB_LOCAL) {

--- a/libcextract/InlineAnalysis.hh
+++ b/libcextract/InlineAnalysis.hh
@@ -32,6 +32,8 @@
 #include <vector>
 #include <stdio.h>
 
+#include <clang/Frontend/ASTUnit.h>
+
 struct IpaCloneNode;
 
 enum ExternalizationType {
@@ -61,6 +63,10 @@ class InlineAnalysis
   {}
 
   ~InlineAnalysis(void);
+
+  /* Update the IPA clones callgraph with more information that is only
+     available if we provide the source code.  */
+  void Update_With_Source_Code_Info(clang::ASTUnit *ast);
 
   /** Get a set of all functions that are inlined into `asm_name`.  */
   std::set<std::string> Get_Inline_Closure_Of_Symbol(const std::string &asm_name);

--- a/libcextract/IpaClonesParser.cpp
+++ b/libcextract/IpaClonesParser.cpp
@@ -161,6 +161,7 @@ IpaCloneNode *IpaClones::Get_Or_Create_Node(const std::string &name)
   /* Not found.  Create it.  */
   IpaCloneNode node;
   node.Name = name;
+  node.Removed = false;
   Nodes[name] = node;
 
   return &Nodes[name];
@@ -271,6 +272,9 @@ void IpaClones::Parse(const char *path)
         callee->InlinedInto.insert(caller);
         caller->Inlines.insert(callee);
       }
+    } else if (decision == IPA_REMOVE) {
+      IpaCloneNode *clone = Get_Or_Create_Node(original_asm_name);
+      clone->Removed = true;
     }
   }
   fclose(file);
@@ -300,11 +304,21 @@ void IpaClones::Dump_Graphviz(const char *filename)
   }
 
   fprintf(file, "strict digraph {");
+
   for (auto &p : Nodes) {
     for (auto &q : p.second.InlinedInto) {
       fprintf(file, "\n\"%s\" -> \"%s\"", p.first.c_str(), q->Name.c_str());
     }
   }
+
+  /* Dot the nodes that we know are removed.  */
+  for (auto &p : Nodes) {
+    IpaCloneNode *node = &p.second;
+    if (node->Removed) {
+      fprintf(file, "\n\"%s\" [style=dotted]", p.first.c_str());
+    }
+  }
+
   fprintf(file, "\n}");
   fclose(file);
 }

--- a/libcextract/IpaClonesParser.cpp
+++ b/libcextract/IpaClonesParser.cpp
@@ -166,6 +166,27 @@ IpaCloneNode *IpaClones::Get_Or_Create_Node(const std::string &name)
   return &Nodes[name];
 }
 
+void IpaClones::Merge_Nodes(IpaCloneNode *to, IpaCloneNode *from)
+{
+  /* Rewire the backedges of nodes that are forward adjacent from `from`.  */
+  for (IpaCloneNode *node : from->InlinedInto) {
+    node->Inlines.erase(from);
+    node->Inlines.insert(to);
+  }
+  for (IpaCloneNode *node : from->Inlines) {
+    node->InlinedInto.erase(from);
+    node->InlinedInto.insert(to);
+  }
+
+  /* Unite the sets.  */
+  to->InlinedInto.insert(from->InlinedInto.begin(), from->InlinedInto.end());
+  to->Inlines.insert(from->Inlines.begin(), from->Inlines.end());
+
+  /* Make sure we aren't self referencing.  */
+  to->InlinedInto.erase(to);
+  to->Inlines.erase(to);
+}
+
 void IpaClones::Parse(const char *path)
 {
   FILE *file = fopen(path, "r");

--- a/libcextract/IpaClonesParser.hh
+++ b/libcextract/IpaClonesParser.hh
@@ -46,6 +46,9 @@ struct IpaCloneNode
 
   /** Which symbols this symbol is inline into?  */
   std::set<IpaCloneNode *> Inlines;
+
+  /** Was this clone marked as removed by IPA?  */
+  bool Removed;
 };
 
 /** @brief Parse .ipa-clone files and build an inline graph.  */

--- a/libcextract/IpaClonesParser.hh
+++ b/libcextract/IpaClonesParser.hh
@@ -105,6 +105,9 @@ class IpaClones : public Parser
     return Get_Or_Create_Node(std::string(name));
   }
 
+  /** Merge node `from` to `to`, releasing `from` in the process.  */
+  void Merge_Nodes(IpaCloneNode *to, IpaCloneNode *from);
+
   /** Iterate through the set of all nodes.  */
   inline std::unordered_map<std::string, IpaCloneNode>::iterator begin()
   {
@@ -113,6 +116,11 @@ class IpaClones : public Parser
   inline std::unordered_map<std::string, IpaCloneNode>::iterator end()
   {
     return Nodes.end();
+  }
+
+  inline void Remove_Node(IpaCloneNode *node)
+  {
+    Nodes.erase(node->Name);
   }
 
   void Dump(void);

--- a/libcextract/NonLLVMMisc.hh
+++ b/libcextract/NonLLVMMisc.hh
@@ -58,6 +58,28 @@ void Remove_Duplicates(std::vector<T>& vec)
   vec.erase(std::unique(vec.begin(), vec.end()), vec.end());
 }
 
+template <typename T>
+bool Remove_Elements_Present_In_2nd_Vector(std::vector<T>& v1, const std::vector<T> &v2)
+{
+  bool ret = false;
+
+  if (v2.size() == 0)
+    return false;
+
+  /* Remove any element in to_externalize that is in NotExternalize.  */
+  for (auto it = v1.begin(); it != v1.end(); it++) {
+    for (auto ij = v2.begin(); ij != v2.end(); ij++) {
+      if (*it == *ij) {
+        v1.erase(it);
+        it--;
+        ret = true;
+      }
+    }
+  }
+
+  return ret;
+}
+
 /** Get a single line from a file, removing its newline.
   *
   * NOTE: if this function return a valid pointer, it must be free'd.

--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -535,11 +535,17 @@ class FunctionExternalizerPass : public Pass
                                       ctx->HeadersToExpand,
                                       ctx->HeadersToNotExpand,
                                       ctx->DumpPasses);
+
+      std::vector<std::string> to_externalize(ctx->Externalize);
+
+      /* Remove any element in to_externalize that is in NotExternalize.  */
+      Remove_Elements_Present_In_2nd_Vector(to_externalize, ctx->NotExternalize);
+
       if (ctx->RenameSymbols)
         /* The FuncExtractNames will be modified, as the function will be renamed.  */
-        externalizer.Externalize_Symbols(ctx->Externalize, ctx->FuncExtractNames);
+        externalizer.Externalize_Symbols(to_externalize, ctx->FuncExtractNames);
       else
-        externalizer.Externalize_Symbols(ctx->Externalize);
+        externalizer.Externalize_Symbols(to_externalize);
 
       externalizer.Commit_Changes_To_Source(ctx->OFS, ctx->MFS, ctx->HeadersToExpand);
 

--- a/libcextract/Passes.cpp
+++ b/libcextract/Passes.cpp
@@ -252,6 +252,9 @@ class BuildASTPass : public Pass
     if (!Build_ASTUnit(ctx))
       return false;
 
+    /* Update the InlineAnalysis object with the source code information.  */
+    ctx->IA.Update_With_Source_Code_Info(ctx->AST.get());
+
     /* Remove any unwanted arguments from command line.  */
     Update_Clang_Args(ctx);
 

--- a/libcextract/Passes.hh
+++ b/libcextract/Passes.hh
@@ -47,6 +47,7 @@ class PassManager {
         Context(ArgvParser &args)
           : FuncExtractNames(args.Get_Functions_To_Extract()),
             Externalize(args.Get_Symbols_To_Externalize()),
+            NotExternalize(args.Get_Symbols_To_Not_Externalize()),
             OutputFile(args.Get_Output_File()),
             IgnoreClangErrors(args.Get_Ignore_Clang_Errors()),
             ExternalizationDisabled(args.Is_Externalization_Disabled()),
@@ -88,6 +89,9 @@ class PassManager {
 
         /** List of functions to externalize.  */
         std::vector<std::string> &Externalize;
+
+        /** List of functions to not externalize.  */
+        std::vector<std::string> &NotExternalize;
 
         /** The final output file name.  */
         std::string &OutputFile;

--- a/meson.build
+++ b/meson.build
@@ -116,7 +116,7 @@ executable('ce-inline', 'Inline.cpp',
   install : true,
   link_args : ['--gcc-install-dir=' + gcc_install_dir],
   link_with : libcextract_static,
-  dependencies : [elf_dep, zlib_dep, zstd_dep]
+  dependencies : [elf_dep, zlib_dep, zstd_dep, clang_dep]
 )
 
 executable('ce-includetree', 'TreeDump.cpp',

--- a/testsuite/ipaclones/cms_kari.c
+++ b/testsuite/ipaclones/cms_kari.c
@@ -1,0 +1,938 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=cms_kek_cipher -DCE_IPACLONES_PATH=$test_dir/cms_kari.c.000i.ipa-clones" }*/
+
+/* This file was processed with clang-extract, originally from openssl-1_1 */
+
+/** clang-extract: from /usr/lib64/clang/22/include/__stddef_size_t.h:18:1 */
+typedef __SIZE_TYPE__ size_t;
+
+/** clang-extract: from /usr/include/bits/types.h:41:1 */
+typedef signed int __int32_t;
+
+/** clang-extract: from /usr/include/bits/stdint-intn.h:26:1 */
+typedef __int32_t int32_t;
+
+#define OPENSSL_FILE __FILE__
+#define OPENSSL_LINE __LINE__
+/** clang-extract: from include/openssl/stack.h:17:1 */
+typedef struct stack_st OPENSSL_STACK;
+
+/** clang-extract: from include/openssl/stack.h:23:1 */
+int OPENSSL_sk_num(const OPENSSL_STACK *);
+
+/** clang-extract: from include/openssl/stack.h:24:1 */
+void *OPENSSL_sk_value(const OPENSSL_STACK *, int);
+
+/** clang-extract: from include/openssl/stack.h:42:1 */
+int OPENSSL_sk_push(OPENSSL_STACK *st, const void *data);
+
+#define STACK_OF(type) struct stack_st_##type
+/** clang-extract: from include/openssl/ossl_typ.h:40:1 */
+typedef struct asn1_string_st ASN1_INTEGER;
+
+/** clang-extract: from include/openssl/ossl_typ.h:41:1 */
+typedef struct asn1_string_st ASN1_ENUMERATED;
+
+/** clang-extract: from include/openssl/ossl_typ.h:42:1 */
+typedef struct asn1_string_st ASN1_BIT_STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:43:1 */
+typedef struct asn1_string_st ASN1_OCTET_STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:44:1 */
+typedef struct asn1_string_st ASN1_PRINTABLESTRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:45:1 */
+typedef struct asn1_string_st ASN1_T61STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:46:1 */
+typedef struct asn1_string_st ASN1_IA5STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:47:1 */
+typedef struct asn1_string_st ASN1_GENERALSTRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:48:1 */
+typedef struct asn1_string_st ASN1_UNIVERSALSTRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:49:1 */
+typedef struct asn1_string_st ASN1_BMPSTRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:50:1 */
+typedef struct asn1_string_st ASN1_UTCTIME;
+
+/** clang-extract: from include/openssl/ossl_typ.h:52:1 */
+typedef struct asn1_string_st ASN1_GENERALIZEDTIME;
+
+/** clang-extract: from include/openssl/ossl_typ.h:53:1 */
+typedef struct asn1_string_st ASN1_VISIBLESTRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:54:1 */
+typedef struct asn1_string_st ASN1_UTF8STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:55:1 */
+typedef struct asn1_string_st ASN1_STRING;
+
+/** clang-extract: from include/openssl/ossl_typ.h:56:1 */
+typedef int ASN1_BOOLEAN;
+
+/** clang-extract: from include/openssl/ossl_typ.h:60:1 */
+typedef struct asn1_object_st ASN1_OBJECT;
+
+/** clang-extract: from include/openssl/ossl_typ.h:62:1 */
+typedef struct ASN1_ITEM_st ASN1_ITEM;
+
+/** clang-extract: from include/openssl/ossl_typ.h:89:1 */
+typedef struct evp_cipher_st EVP_CIPHER;
+
+/** clang-extract: from include/openssl/ossl_typ.h:90:1 */
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+
+/** clang-extract: from include/openssl/ossl_typ.h:93:1 */
+typedef struct evp_pkey_st EVP_PKEY;
+
+/** clang-extract: from include/openssl/ossl_typ.h:98:1 */
+typedef struct evp_pkey_ctx_st EVP_PKEY_CTX;
+
+/** clang-extract: from include/openssl/ossl_typ.h:123:1 */
+typedef struct x509_st X509;
+
+/** clang-extract: from include/openssl/ossl_typ.h:124:1 */
+typedef struct X509_algor_st X509_ALGOR;
+
+/** clang-extract: from include/openssl/ossl_typ.h:128:1 */
+typedef struct X509_name_st X509_NAME;
+
+/** clang-extract: from include/openssl/ossl_typ.h:149:1 */
+typedef struct engine_st ENGINE;
+
+#define OPENSSL_malloc(num) \
+        CRYPTO_malloc(num, OPENSSL_FILE, OPENSSL_LINE)
+#define OPENSSL_clear_free(addr, num) \
+        CRYPTO_clear_free(addr, num, OPENSSL_FILE, OPENSSL_LINE)
+#define OPENSSL_free(addr) \
+        CRYPTO_free(addr, OPENSSL_FILE, OPENSSL_LINE)
+/** clang-extract: from include/openssl/crypto.h:266:1 */
+void *CRYPTO_malloc(size_t num, const char *file, int line);
+
+/** clang-extract: from include/openssl/crypto.h:271:1 */
+void CRYPTO_free(void *ptr, const char *file, int line);
+
+/** clang-extract: from include/openssl/crypto.h:272:1 */
+void CRYPTO_clear_free(void *ptr, size_t num, const char *file, int line);
+
+/** clang-extract: from include/openssl/crypto.h:289:1 */
+void OPENSSL_cleanse(void *ptr, size_t len);
+
+#define NULL ((void*)0)
+#define ERR_PUT_error(a,b,c,d,e)        ERR_put_error(a,b,c,d,e)
+#define ERR_LIB_CMS             46
+#define CMSerr(f,r) ERR_PUT_error(ERR_LIB_CMS,(f),(r),OPENSSL_FILE,OPENSSL_LINE)
+/** clang-extract: from include/openssl/err.h:220:1 */
+void ERR_put_error(int lib, int func, int reason, const char *file, int line);
+
+/** clang-extract: from include/openssl/asn1.h:146:1 */
+struct asn1_string_st {
+    int length;
+    int type;
+    unsigned char *data;
+    /*
+     * The value of the following field depends on the type being held.  It
+     * is mostly being used for BIT_STRING so if the input data has a
+     * non-zero 'unused bits' value, it will be handled correctly
+     */
+    long flags;
+};
+
+/** clang-extract: from include/openssl/asn1.h:213:1 */
+typedef struct ASN1_VALUE_st ASN1_VALUE;
+
+#define CHECKED_PTR_OF(type, p) \
+    ((void*) (1 ? p : (type*)0))
+#define ASN1_ITEM_rptr(ref) (&(ref##_it))
+/** clang-extract: from include/openssl/asn1.h:444:1 */
+typedef struct asn1_type_st {
+    int type;
+    union {
+        char *ptr;
+        ASN1_BOOLEAN boolean;
+        ASN1_STRING *asn1_string;
+        ASN1_OBJECT *object;
+        ASN1_INTEGER *integer;
+        ASN1_ENUMERATED *enumerated;
+        ASN1_BIT_STRING *bit_string;
+        ASN1_OCTET_STRING *octet_string;
+        ASN1_PRINTABLESTRING *printablestring;
+        ASN1_T61STRING *t61string;
+        ASN1_IA5STRING *ia5string;
+        ASN1_GENERALSTRING *generalstring;
+        ASN1_BMPSTRING *bmpstring;
+        ASN1_UNIVERSALSTRING *universalstring;
+        ASN1_UTCTIME *utctime;
+        ASN1_GENERALIZEDTIME *generalizedtime;
+        ASN1_VISIBLESTRING *visiblestring;
+        ASN1_UTF8STRING *utf8string;
+        /*
+         * set and sequence are left complete and still contain the set or
+         * sequence bytes
+         */
+        ASN1_STRING *set;
+        ASN1_STRING *sequence;
+        ASN1_VALUE *asn1_value;
+    } value;
+} ASN1_TYPE;
+
+/** clang-extract: from include/openssl/asn1.h:550:1 */
+void ASN1_STRING_set0(ASN1_STRING *str, void *data, int len);
+
+#define M_ASN1_new_of(type) (type *)ASN1_item_new(ASN1_ITEM_rptr(type))
+#define M_ASN1_free_of(x, type) \
+                ASN1_item_free(CHECKED_PTR_OF(type, x), ASN1_ITEM_rptr(type))
+/** clang-extract: from include/openssl/asn1.h:806:1 */
+ASN1_VALUE *ASN1_item_new(const ASN1_ITEM *it);
+
+/** clang-extract: from include/openssl/asn1.h:807:1 */
+void ASN1_item_free(ASN1_VALUE *val, const ASN1_ITEM *it);
+
+#define EVP_MAX_KEY_LENGTH              64
+#define NID_des_ede3_cbc                44
+#define EVP_CIPH_WRAP_MODE              0x10002
+#define EVP_CIPH_MODE                   0xF0007
+/** clang-extract: from include/openssl/evp.h:468:1 */
+int EVP_CIPHER_key_length(const EVP_CIPHER *cipher);
+
+/** clang-extract: from include/openssl/evp.h:470:1 */
+unsigned long EVP_CIPHER_flags(const EVP_CIPHER *cipher);
+
+#define EVP_CIPHER_mode(e)              (EVP_CIPHER_flags(e) & EVP_CIPH_MODE)
+/** clang-extract: from include/openssl/evp.h:473:1 */
+const EVP_CIPHER *EVP_CIPHER_CTX_cipher(const EVP_CIPHER_CTX *ctx);
+
+/** clang-extract: from include/openssl/evp.h:477:1 */
+int EVP_CIPHER_CTX_key_length(const EVP_CIPHER_CTX *ctx);
+
+#define EVP_CIPHER_CTX_mode(c)         EVP_CIPHER_mode(EVP_CIPHER_CTX_cipher(c))
+/** clang-extract: from include/openssl/evp.h:582:12 */
+int EVP_EncryptInit_ex(EVP_CIPHER_CTX *ctx,
+                                  const EVP_CIPHER *cipher, ENGINE *impl,
+                                  const unsigned char *key,
+                                  const unsigned char *iv);
+
+/** clang-extract: from include/openssl/evp.h:609:12 */
+int EVP_CipherInit_ex(EVP_CIPHER_CTX *ctx,
+                                 const EVP_CIPHER *cipher, ENGINE *impl,
+                                 const unsigned char *key,
+                                 const unsigned char *iv, int enc);
+
+/** clang-extract: from include/openssl/evp.h:613:8 */
+int EVP_CipherUpdate(EVP_CIPHER_CTX *ctx, unsigned char *out,
+                            int *outl, const unsigned char *in, int inl);
+
+/** clang-extract: from include/openssl/evp.h:680:1 */
+int EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c);
+
+/** clang-extract: from include/openssl/evp.h:758:1 */
+const EVP_CIPHER *EVP_des_ede3_wrap(void);
+
+/** clang-extract: from include/openssl/evp.h:820:1 */
+const EVP_CIPHER *EVP_aes_128_wrap(void);
+
+/** clang-extract: from include/openssl/evp.h:835:1 */
+const EVP_CIPHER *EVP_aes_192_wrap(void);
+
+/** clang-extract: from include/openssl/evp.h:851:1 */
+const EVP_CIPHER *EVP_aes_256_wrap(void);
+
+/** clang-extract: from include/openssl/evp.h:1040:1 */
+int EVP_PKEY_up_ref(EVP_PKEY *pkey);
+
+/** clang-extract: from include/openssl/evp.h:1041:1 */
+void EVP_PKEY_free(EVP_PKEY *pkey);
+
+/** clang-extract: from include/openssl/evp.h:1073:1 */
+int EVP_CIPHER_type(const EVP_CIPHER *ctx);
+
+/** clang-extract: from include/openssl/evp.h:1341:1 */
+EVP_PKEY_CTX *EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
+
+/** clang-extract: from include/openssl/evp.h:1344:1 */
+void EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
+
+/** clang-extract: from include/openssl/evp.h:1407:1 */
+int EVP_PKEY_derive_init(EVP_PKEY_CTX *ctx);
+
+/** clang-extract: from include/openssl/evp.h:1408:1 */
+int EVP_PKEY_derive_set_peer(EVP_PKEY_CTX *ctx, EVP_PKEY *peer);
+
+/** clang-extract: from include/openssl/evp.h:1409:1 */
+int EVP_PKEY_derive(EVP_PKEY_CTX *ctx, unsigned char *key, size_t *keylen);
+
+/** clang-extract: from include/openssl/evp.h:1415:1 */
+int EVP_PKEY_keygen_init(EVP_PKEY_CTX *ctx);
+
+/** clang-extract: from include/openssl/evp.h:1416:1 */
+int EVP_PKEY_keygen(EVP_PKEY_CTX *ctx, EVP_PKEY **ppkey);
+
+/** clang-extract: from include/openssl/x509.h:89:1 */
+struct stack_st_X509_ATTRIBUTE;/* Full definition was removed.  */
+
+#define CMS_F_CMS_RECIPIENTINFO_KARI_ENCRYPT             178
+#define CMS_F_CMS_RECIPIENTINFO_KARI_GET0_ALG            175
+#define CMS_F_CMS_RECIPIENTINFO_KARI_GET0_ORIG_ID        173
+#define CMS_F_CMS_RECIPIENTINFO_KARI_GET0_REKS           172
+#define CMS_F_CMS_RECIPIENTINFO_KARI_ORIG_ID_CMP         174
+#define CMS_R_NOT_KEY_AGREEMENT                          181
+/** clang-extract: from include/openssl/cms.h:23:1 */
+typedef struct CMS_ContentInfo_st CMS_ContentInfo;
+
+/** clang-extract: from include/openssl/cms.h:27:1 */
+typedef struct CMS_RecipientInfo_st CMS_RecipientInfo;
+
+/** clang-extract: from include/openssl/cms.h:30:1 */
+typedef struct CMS_RecipientEncryptedKey_st CMS_RecipientEncryptedKey;
+
+/** clang-extract: from include/openssl/cms.h:31:1 */
+typedef struct CMS_OtherKeyAttribute_st CMS_OtherKeyAttribute;
+
+/** clang-extract: from include/openssl/cms.h:34:1 */
+struct stack_st_CMS_RecipientEncryptedKey;/* Full definition was removed.  */
+
+/** clang-extract: from include/openssl/cms.h:34:1 */
+__attribute__((unused)) static inline int sk_CMS_RecipientEncryptedKey_num(const struct stack_st_CMS_RecipientEncryptedKey *sk) {
+    return OPENSSL_sk_num((const OPENSSL_STACK *)sk);
+}
+
+/** clang-extract: from include/openssl/cms.h:34:1 */
+__attribute__((unused)) static inline CMS_RecipientEncryptedKey *sk_CMS_RecipientEncryptedKey_value(const struct stack_st_CMS_RecipientEncryptedKey *sk, int idx) {
+    return (CMS_RecipientEncryptedKey *)OPENSSL_sk_value((const OPENSSL_STACK *)sk, idx);
+}
+
+/** clang-extract: from include/openssl/cms.h:34:1 */
+__attribute__((unused)) static inline int sk_CMS_RecipientEncryptedKey_push(struct stack_st_CMS_RecipientEncryptedKey *sk, CMS_RecipientEncryptedKey *ptr) {
+    return OPENSSL_sk_push((OPENSSL_STACK *)sk, (const void *)ptr);
+}
+
+/** clang-extract: from include/openssl/cms.h:35:1 */
+struct stack_st_CMS_RecipientInfo;/* Full definition was removed.  */
+
+#define CMS_RECIPINFO_AGREE             1
+#define CMS_USE_KEYID                   0x10000
+/** clang-extract: from include/openssl/cms.h:299:1 */
+int CMS_RecipientInfo_kari_get0_alg(CMS_RecipientInfo *ri,
+                                    X509_ALGOR **palg,
+                                    ASN1_OCTET_STRING **pukm);
+
+/** clang-extract: from include/openssl/cms.h:302:1 */
+STACK_OF(CMS_RecipientEncryptedKey)
+*CMS_RecipientInfo_kari_get0_reks(CMS_RecipientInfo *ri);
+
+/** clang-extract: from include/openssl/cms.h:305:1 */
+int CMS_RecipientInfo_kari_get0_orig_id(CMS_RecipientInfo *ri,
+                                        X509_ALGOR **pubalg,
+                                        ASN1_BIT_STRING **pubkey,
+                                        ASN1_OCTET_STRING **keyid,
+                                        X509_NAME **issuer,
+                                        ASN1_INTEGER **sno);
+
+/** clang-extract: from include/openssl/cms.h:312:1 */
+int CMS_RecipientInfo_kari_orig_id_cmp(CMS_RecipientInfo *ri, X509 *cert);
+
+/** clang-extract: from include/openssl/cms.h:314:1 */
+int CMS_RecipientEncryptedKey_get0_id(CMS_RecipientEncryptedKey *rek,
+                                      ASN1_OCTET_STRING **keyid,
+                                      ASN1_GENERALIZEDTIME **tm,
+                                      CMS_OtherKeyAttribute **other,
+                                      X509_NAME **issuer, ASN1_INTEGER **sno);
+
+/** clang-extract: from include/openssl/cms.h:319:1 */
+int CMS_RecipientEncryptedKey_cert_cmp(CMS_RecipientEncryptedKey *rek,
+                                       X509 *cert);
+
+/** clang-extract: from include/openssl/cms.h:323:1 */
+int CMS_RecipientInfo_kari_decrypt(CMS_ContentInfo *cms,
+                                   CMS_RecipientInfo *ri,
+                                   CMS_RecipientEncryptedKey *rek);
+
+/** clang-extract: from crypto/cms/cms_local.h:21:1 */
+typedef struct CMS_IssuerAndSerialNumber_st CMS_IssuerAndSerialNumber;
+
+/** clang-extract: from crypto/cms/cms_local.h:24:1 */
+typedef struct CMS_SignedData_st CMS_SignedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:26:1 */
+typedef struct CMS_OriginatorInfo_st CMS_OriginatorInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:27:1 */
+typedef struct CMS_EncryptedContentInfo_st CMS_EncryptedContentInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:28:1 */
+typedef struct CMS_EnvelopedData_st CMS_EnvelopedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:29:1 */
+typedef struct CMS_DigestedData_st CMS_DigestedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:30:1 */
+typedef struct CMS_EncryptedData_st CMS_EncryptedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:31:1 */
+typedef struct CMS_AuthenticatedData_st CMS_AuthenticatedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:32:1 */
+typedef struct CMS_CompressedData_st CMS_CompressedData;
+
+/** clang-extract: from crypto/cms/cms_local.h:34:1 */
+typedef struct CMS_KeyTransRecipientInfo_st CMS_KeyTransRecipientInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:35:1 */
+typedef struct CMS_OriginatorPublicKey_st CMS_OriginatorPublicKey;
+
+/** clang-extract: from crypto/cms/cms_local.h:36:1 */
+typedef struct CMS_OriginatorIdentifierOrKey_st CMS_OriginatorIdentifierOrKey;
+
+/** clang-extract: from crypto/cms/cms_local.h:37:1 */
+typedef struct CMS_KeyAgreeRecipientInfo_st CMS_KeyAgreeRecipientInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:38:1 */
+typedef struct CMS_RecipientKeyIdentifier_st CMS_RecipientKeyIdentifier;
+
+/** clang-extract: from crypto/cms/cms_local.h:39:1 */
+typedef struct CMS_KeyAgreeRecipientIdentifier_st
+    CMS_KeyAgreeRecipientIdentifier;
+
+/** clang-extract: from crypto/cms/cms_local.h:42:1 */
+typedef struct CMS_KEKRecipientInfo_st CMS_KEKRecipientInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:43:1 */
+typedef struct CMS_PasswordRecipientInfo_st CMS_PasswordRecipientInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:44:1 */
+typedef struct CMS_OtherRecipientInfo_st CMS_OtherRecipientInfo;
+
+/** clang-extract: from crypto/cms/cms_local.h:47:1 */
+struct CMS_ContentInfo_st {
+    ASN1_OBJECT *contentType;
+    union {
+        ASN1_OCTET_STRING *data;
+        CMS_SignedData *signedData;
+        CMS_EnvelopedData *envelopedData;
+        CMS_DigestedData *digestedData;
+        CMS_EncryptedData *encryptedData;
+        CMS_AuthenticatedData *authenticatedData;
+        CMS_CompressedData *compressedData;
+        ASN1_TYPE *other;
+        /* Other types ... */
+        void *otherData;
+    } d;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:105:1 */
+struct CMS_EnvelopedData_st {
+    int32_t version;
+    CMS_OriginatorInfo *originatorInfo;
+    STACK_OF(CMS_RecipientInfo) *recipientInfos;
+    CMS_EncryptedContentInfo *encryptedContentInfo;
+    STACK_OF(X509_ATTRIBUTE) *unprotectedAttrs;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:118:1 */
+struct CMS_EncryptedContentInfo_st {
+    ASN1_OBJECT *contentType;
+    X509_ALGOR *contentEncryptionAlgorithm;
+    ASN1_OCTET_STRING *encryptedContent;
+    /* Content encryption algorithm and key */
+    const EVP_CIPHER *cipher;
+    unsigned char *key;
+    size_t keylen;
+    /* Set to 1 if we are debugging decrypt and don't fake keys for MMA */
+    int debug;
+    /* Set to 1 if we have no cert and need extra safety measures for MMA */
+    int havenocert;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:132:1 */
+struct CMS_RecipientInfo_st {
+    int type;
+    union {
+        CMS_KeyTransRecipientInfo *ktri;
+        CMS_KeyAgreeRecipientInfo *kari;
+        CMS_KEKRecipientInfo *kekri;
+        CMS_PasswordRecipientInfo *pwri;
+        CMS_OtherRecipientInfo *ori;
+    } d;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:157:1 */
+struct CMS_KeyAgreeRecipientInfo_st {
+    int32_t version;
+    CMS_OriginatorIdentifierOrKey *originator;
+    ASN1_OCTET_STRING *ukm;
+    X509_ALGOR *keyEncryptionAlgorithm;
+    STACK_OF(CMS_RecipientEncryptedKey) *recipientEncryptedKeys;
+    /* Public key context associated with current operation */
+    EVP_PKEY_CTX *pctx;
+    /* Cipher context for CEK wrapping */
+    EVP_CIPHER_CTX *ctx;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:169:1 */
+struct CMS_OriginatorIdentifierOrKey_st {
+    int type;
+    union {
+        CMS_IssuerAndSerialNumber *issuerAndSerialNumber;
+        ASN1_OCTET_STRING *subjectKeyIdentifier;
+        CMS_OriginatorPublicKey *originatorKey;
+    } d;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:178:1 */
+struct CMS_OriginatorPublicKey_st {
+    X509_ALGOR *algorithm;
+    ASN1_BIT_STRING *publicKey;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:183:1 */
+struct CMS_RecipientEncryptedKey_st {
+    CMS_KeyAgreeRecipientIdentifier *rid;
+    ASN1_OCTET_STRING *encryptedKey;
+    /* Public key associated with this recipient */
+    EVP_PKEY *pkey;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:190:1 */
+struct CMS_KeyAgreeRecipientIdentifier_st {
+    int type;
+    union {
+        CMS_IssuerAndSerialNumber *issuerAndSerialNumber;
+        CMS_RecipientKeyIdentifier *rKeyId;
+    } d;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:198:1 */
+struct CMS_RecipientKeyIdentifier_st {
+    ASN1_OCTET_STRING *subjectKeyIdentifier;
+    ASN1_GENERALIZEDTIME *date;
+    CMS_OtherKeyAttribute *other;
+};
+
+/** clang-extract: from crypto/cms/cms_local.h:310:1 */
+struct CMS_IssuerAndSerialNumber_st {
+    X509_NAME *issuer;
+    ASN1_INTEGER *serialNumber;
+};
+
+#define CMS_REK_ISSUER_SERIAL           0
+#define CMS_REK_KEYIDENTIFIER           1
+#define CMS_OIK_ISSUER_SERIAL           0
+#define CMS_OIK_KEYIDENTIFIER           1
+#define CMS_OIK_PUBKEY                  2
+/** clang-extract: from crypto/cms/cms_local.h:391:1 */
+int cms_ias_cert_cmp(CMS_IssuerAndSerialNumber *ias, X509 *cert);
+
+/** clang-extract: from crypto/cms/cms_local.h:392:1 */
+int cms_keyid_cert_cmp(ASN1_OCTET_STRING *keyid, X509 *cert);
+
+/** clang-extract: from crypto/cms/cms_local.h:393:1 */
+int cms_set1_ias(CMS_IssuerAndSerialNumber **pias, X509 *cert);
+
+/** clang-extract: from crypto/cms/cms_local.h:394:1 */
+int cms_set1_keyid(ASN1_OCTET_STRING **pkeyid, X509 *cert);
+
+/** clang-extract: from crypto/cms/cms_local.h:408:1 */
+int cms_env_asn1_ctrl(CMS_RecipientInfo *ri, int cmd);
+
+/** clang-extract: from crypto/cms/cms_local.h:411:1 */
+int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri, X509 *recip,
+                                EVP_PKEY *pk, unsigned int flags);
+
+/** clang-extract: from crypto/cms/cms_local.h:413:1 */
+int cms_RecipientInfo_kari_encrypt(CMS_ContentInfo *cms,
+                                   CMS_RecipientInfo *ri);
+
+/** clang-extract: from crypto/cms/cms_local.h:427:1 */
+extern const ASN1_ITEM CMS_KeyAgreeRecipientInfo_it;
+
+/** clang-extract: from crypto/cms/cms_local.h:429:1 */
+extern const ASN1_ITEM CMS_OriginatorPublicKey_it;
+
+/** clang-extract: from crypto/cms/cms_local.h:433:1 */
+extern const ASN1_ITEM CMS_RecipientEncryptedKey_it;
+
+/** clang-extract: from crypto/cms/cms_local.h:434:1 */
+extern const ASN1_ITEM CMS_RecipientKeyIdentifier_it;
+
+/** clang-extract: from crypto/cms/cms_kari.c:22:1 */
+int CMS_RecipientInfo_kari_get0_alg(CMS_RecipientInfo *ri,
+                                    X509_ALGOR **palg,
+                                    ASN1_OCTET_STRING **pukm)
+{
+    if (ri->type != CMS_RECIPINFO_AGREE) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KARI_GET0_ALG,
+               CMS_R_NOT_KEY_AGREEMENT);
+        return 0;
+    }
+    if (palg)
+        *palg = ri->d.kari->keyEncryptionAlgorithm;
+    if (pukm)
+        *pukm = ri->d.kari->ukm;
+    return 1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:40:1 */
+STACK_OF(CMS_RecipientEncryptedKey)
+*CMS_RecipientInfo_kari_get0_reks(CMS_RecipientInfo *ri)
+{
+    if (ri->type != CMS_RECIPINFO_AGREE) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KARI_GET0_REKS,
+               CMS_R_NOT_KEY_AGREEMENT);
+        return NULL;
+    }
+    return ri->d.kari->recipientEncryptedKeys;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:51:1 */
+int CMS_RecipientInfo_kari_get0_orig_id(CMS_RecipientInfo *ri,
+                                        X509_ALGOR **pubalg,
+                                        ASN1_BIT_STRING **pubkey,
+                                        ASN1_OCTET_STRING **keyid,
+                                        X509_NAME **issuer,
+                                        ASN1_INTEGER **sno)
+{
+    CMS_OriginatorIdentifierOrKey *oik;
+    if (ri->type != CMS_RECIPINFO_AGREE) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KARI_GET0_ORIG_ID,
+               CMS_R_NOT_KEY_AGREEMENT);
+        return 0;
+    }
+    oik = ri->d.kari->originator;
+    if (issuer)
+        *issuer = NULL;
+    if (sno)
+        *sno = NULL;
+    if (keyid)
+        *keyid = NULL;
+    if (pubalg)
+        *pubalg = NULL;
+    if (pubkey)
+        *pubkey = NULL;
+    if (oik->type == CMS_OIK_ISSUER_SERIAL) {
+        if (issuer)
+            *issuer = oik->d.issuerAndSerialNumber->issuer;
+        if (sno)
+            *sno = oik->d.issuerAndSerialNumber->serialNumber;
+    } else if (oik->type == CMS_OIK_KEYIDENTIFIER) {
+        if (keyid)
+            *keyid = oik->d.subjectKeyIdentifier;
+    } else if (oik->type == CMS_OIK_PUBKEY) {
+        if (pubalg)
+            *pubalg = oik->d.originatorKey->algorithm;
+        if (pubkey)
+            *pubkey = oik->d.originatorKey->publicKey;
+    } else
+        return 0;
+    return 1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:93:1 */
+int CMS_RecipientInfo_kari_orig_id_cmp(CMS_RecipientInfo *ri, X509 *cert)
+{
+    CMS_OriginatorIdentifierOrKey *oik;
+    if (ri->type != CMS_RECIPINFO_AGREE) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KARI_ORIG_ID_CMP,
+               CMS_R_NOT_KEY_AGREEMENT);
+        return -2;
+    }
+    oik = ri->d.kari->originator;
+    if (oik->type == CMS_OIK_ISSUER_SERIAL)
+        return cms_ias_cert_cmp(oik->d.issuerAndSerialNumber, cert);
+    else if (oik->type == CMS_OIK_KEYIDENTIFIER)
+        return cms_keyid_cert_cmp(oik->d.subjectKeyIdentifier, cert);
+    return -1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:109:1 */
+int CMS_RecipientEncryptedKey_get0_id(CMS_RecipientEncryptedKey *rek,
+                                      ASN1_OCTET_STRING **keyid,
+                                      ASN1_GENERALIZEDTIME **tm,
+                                      CMS_OtherKeyAttribute **other,
+                                      X509_NAME **issuer, ASN1_INTEGER **sno)
+{
+    CMS_KeyAgreeRecipientIdentifier *rid = rek->rid;
+    if (rid->type == CMS_REK_ISSUER_SERIAL) {
+        if (issuer)
+            *issuer = rid->d.issuerAndSerialNumber->issuer;
+        if (sno)
+            *sno = rid->d.issuerAndSerialNumber->serialNumber;
+        if (keyid)
+            *keyid = NULL;
+        if (tm)
+            *tm = NULL;
+        if (other)
+            *other = NULL;
+    } else if (rid->type == CMS_REK_KEYIDENTIFIER) {
+        if (keyid)
+            *keyid = rid->d.rKeyId->subjectKeyIdentifier;
+        if (tm)
+            *tm = rid->d.rKeyId->date;
+        if (other)
+            *other = rid->d.rKeyId->other;
+        if (issuer)
+            *issuer = NULL;
+        if (sno)
+            *sno = NULL;
+    } else
+        return 0;
+    return 1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:143:1 */
+int CMS_RecipientEncryptedKey_cert_cmp(CMS_RecipientEncryptedKey *rek,
+                                       X509 *cert)
+{
+    CMS_KeyAgreeRecipientIdentifier *rid = rek->rid;
+    if (rid->type == CMS_REK_ISSUER_SERIAL)
+        return cms_ias_cert_cmp(rid->d.issuerAndSerialNumber, cert);
+    else if (rid->type == CMS_REK_KEYIDENTIFIER)
+        return cms_keyid_cert_cmp(rid->d.rKeyId->subjectKeyIdentifier, cert);
+    else
+        return -1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:186:1 */
+static int cms_kek_cipher(unsigned char **pout, size_t *poutlen,
+                          const unsigned char *in, size_t inlen,
+                          CMS_KeyAgreeRecipientInfo *kari, int enc)
+{
+    /* Key encryption key */
+    unsigned char kek[EVP_MAX_KEY_LENGTH];
+    size_t keklen;
+    int rv = 0;
+    unsigned char *out = NULL;
+    int outlen;
+    size_t outsize;
+    keklen = EVP_CIPHER_CTX_key_length(kari->ctx);
+    if (keklen > EVP_MAX_KEY_LENGTH)
+        return 0;
+    /* Derive KEK */
+    if (EVP_PKEY_derive(kari->pctx, kek, &keklen) <= 0)
+        goto err;
+    /* Set KEK in context */
+    if (!EVP_CipherInit_ex(kari->ctx, NULL, NULL, kek, NULL, enc))
+        goto err;
+    /* obtain output length of ciphered key */
+    if (!EVP_CipherUpdate(kari->ctx, NULL, &outlen, in, inlen))
+        goto err;
+    /*
+     * On its integrity-failure paths that primitive writes and cleanses up to
+     * inlen bytes of the output buffer. Size the buffer for that worst case so
+     * a failed unwrap cannot write past the allocation.
+     */
+    outsize = (size_t)outlen < inlen ? inlen : (size_t)outlen;
+    out = OPENSSL_malloc(outsize);
+    if (out == NULL)
+        goto err;
+    if (!EVP_CipherUpdate(kari->ctx, out, &outlen, in, inlen))
+        goto err;
+    *pout = out;
+    *poutlen = (size_t)outlen;
+    rv = 1;
+
+ err:
+    OPENSSL_cleanse(kek, keklen);
+    if (!rv)
+        OPENSSL_free(out);
+    EVP_CIPHER_CTX_reset(kari->ctx);
+    /* FIXME: WHY IS kari->pctx freed here?  /RL */
+    EVP_PKEY_CTX_free(kari->pctx);
+    kari->pctx = NULL;
+    return rv;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:235:1 */
+int CMS_RecipientInfo_kari_decrypt(CMS_ContentInfo *cms,
+                                   CMS_RecipientInfo *ri,
+                                   CMS_RecipientEncryptedKey *rek)
+{
+    int rv = 0;
+    unsigned char *enckey = NULL, *cek = NULL;
+    size_t enckeylen;
+    size_t ceklen;
+    CMS_EncryptedContentInfo *ec;
+    enckeylen = rek->encryptedKey->length;
+    enckey = rek->encryptedKey->data;
+    /* Setup all parameters to derive KEK */
+    if (!cms_env_asn1_ctrl(ri, 1))
+        goto err;
+    /* Attempt to decrypt CEK */
+    if (!cms_kek_cipher(&cek, &ceklen, enckey, enckeylen, ri->d.kari, 0))
+        goto err;
+    ec = cms->d.envelopedData->encryptedContentInfo;
+    OPENSSL_clear_free(ec->key, ec->keylen);
+    ec->key = cek;
+    ec->keylen = ceklen;
+    cek = NULL;
+    rv = 1;
+ err:
+    OPENSSL_free(cek);
+    return rv;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:264:1 */
+static int cms_kari_create_ephemeral_key(CMS_KeyAgreeRecipientInfo *kari,
+                                         EVP_PKEY *pk)
+{
+    EVP_PKEY_CTX *pctx = NULL;
+    EVP_PKEY *ekey = NULL;
+    int rv = 0;
+    pctx = EVP_PKEY_CTX_new(pk, NULL);
+    if (!pctx)
+        goto err;
+    if (EVP_PKEY_keygen_init(pctx) <= 0)
+        goto err;
+    if (EVP_PKEY_keygen(pctx, &ekey) <= 0)
+        goto err;
+    EVP_PKEY_CTX_free(pctx);
+    pctx = EVP_PKEY_CTX_new(ekey, NULL);
+    if (!pctx)
+        goto err;
+    if (EVP_PKEY_derive_init(pctx) <= 0)
+        goto err;
+    kari->pctx = pctx;
+    rv = 1;
+ err:
+    if (!rv)
+        EVP_PKEY_CTX_free(pctx);
+    EVP_PKEY_free(ekey);
+    return rv;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:294:1 */
+int cms_RecipientInfo_kari_init(CMS_RecipientInfo *ri, X509 *recip,
+                                EVP_PKEY *pk, unsigned int flags)
+{
+    CMS_KeyAgreeRecipientInfo *kari;
+    CMS_RecipientEncryptedKey *rek = NULL;
+
+    ri->d.kari = M_ASN1_new_of(CMS_KeyAgreeRecipientInfo);
+    if (!ri->d.kari)
+        return 0;
+    ri->type = CMS_RECIPINFO_AGREE;
+
+    kari = ri->d.kari;
+    kari->version = 3;
+
+    rek = M_ASN1_new_of(CMS_RecipientEncryptedKey);
+    if (rek == NULL)
+        return 0;
+
+    if (!sk_CMS_RecipientEncryptedKey_push(kari->recipientEncryptedKeys, rek)) {
+        M_ASN1_free_of(rek, CMS_RecipientEncryptedKey);
+        return 0;
+    }
+
+    if (flags & CMS_USE_KEYID) {
+        rek->rid->type = CMS_REK_KEYIDENTIFIER;
+        rek->rid->d.rKeyId = M_ASN1_new_of(CMS_RecipientKeyIdentifier);
+        if (rek->rid->d.rKeyId == NULL)
+            return 0;
+        if (!cms_set1_keyid(&rek->rid->d.rKeyId->subjectKeyIdentifier, recip))
+            return 0;
+    } else {
+        rek->rid->type = CMS_REK_ISSUER_SERIAL;
+        if (!cms_set1_ias(&rek->rid->d.issuerAndSerialNumber, recip))
+            return 0;
+    }
+
+    /* Create ephemeral key */
+    if (!cms_kari_create_ephemeral_key(kari, pk))
+        return 0;
+
+    EVP_PKEY_up_ref(pk);
+    rek->pkey = pk;
+    return 1;
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:339:1 */
+static int cms_wrap_init(CMS_KeyAgreeRecipientInfo *kari,
+                         const EVP_CIPHER *cipher)
+{
+    EVP_CIPHER_CTX *ctx = kari->ctx;
+    const EVP_CIPHER *kekcipher;
+    int keylen = EVP_CIPHER_key_length(cipher);
+    /* If a suitable wrap algorithm is already set nothing to do */
+    kekcipher = EVP_CIPHER_CTX_cipher(ctx);
+
+    if (kekcipher) {
+        if (EVP_CIPHER_CTX_mode(ctx) != EVP_CIPH_WRAP_MODE)
+            return 0;
+        return 1;
+    }
+    /*
+     * Pick a cipher based on content encryption cipher. If it is DES3 use
+     * DES3 wrap otherwise use AES wrap similar to key size.
+     */
+#ifndef OPENSSL_NO_DES
+    if (EVP_CIPHER_type(cipher) == NID_des_ede3_cbc)
+        kekcipher = EVP_des_ede3_wrap();
+    else
+#endif
+    if (keylen <= 16)
+        kekcipher = EVP_aes_128_wrap();
+    else if (keylen <= 24)
+        kekcipher = EVP_aes_192_wrap();
+    else
+        kekcipher = EVP_aes_256_wrap();
+    return EVP_EncryptInit_ex(ctx, kekcipher, NULL, NULL, NULL);
+}
+
+/** clang-extract: from crypto/cms/cms_kari.c:373:1 */
+int cms_RecipientInfo_kari_encrypt(CMS_ContentInfo *cms,
+                                   CMS_RecipientInfo *ri)
+{
+    CMS_KeyAgreeRecipientInfo *kari;
+    CMS_EncryptedContentInfo *ec;
+    CMS_RecipientEncryptedKey *rek;
+    STACK_OF(CMS_RecipientEncryptedKey) *reks;
+    int i;
+
+    if (ri->type != CMS_RECIPINFO_AGREE) {
+        CMSerr(CMS_F_CMS_RECIPIENTINFO_KARI_ENCRYPT, CMS_R_NOT_KEY_AGREEMENT);
+        return 0;
+    }
+    kari = ri->d.kari;
+    reks = kari->recipientEncryptedKeys;
+    ec = cms->d.envelopedData->encryptedContentInfo;
+    /* Initialise wrap algorithm parameters */
+    if (!cms_wrap_init(kari, ec->cipher))
+        return 0;
+    /*
+     * If no originator key set up initialise for ephemeral key the public key
+     * ASN1 structure will set the actual public key value.
+     */
+    if (kari->originator->type == -1) {
+        CMS_OriginatorIdentifierOrKey *oik = kari->originator;
+        oik->type = CMS_OIK_PUBKEY;
+        oik->d.originatorKey = M_ASN1_new_of(CMS_OriginatorPublicKey);
+        if (!oik->d.originatorKey)
+            return 0;
+    }
+    /* Initialise KDF algorithm */
+    if (!cms_env_asn1_ctrl(ri, 0))
+        return 0;
+    /* For each rek, derive KEK, encrypt CEK */
+    for (i = 0; i < sk_CMS_RecipientEncryptedKey_num(reks); i++) {
+        unsigned char *enckey;
+        size_t enckeylen;
+        rek = sk_CMS_RecipientEncryptedKey_value(reks, i);
+        if (EVP_PKEY_derive_set_peer(kari->pctx, rek->pkey) <= 0)
+            return 0;
+        if (!cms_kek_cipher(&enckey, &enckeylen, ec->key, ec->keylen,
+                            kari, 1))
+            return 0;
+        ASN1_STRING_set0(rek->encryptedKey, enckey, enckeylen);
+    }
+
+    return 1;
+
+}
+
+/* The following functions must be output with their full definition.  */
+/* { dg-final { scan-tree-dump "cms_RecipientInfo_kari_encrypt\(.*\n.*\)\n{" } } */
+/* { dg-final { scan-tree-dump "CMS_RecipientInfo_kari_decrypt\(.*\n.*\n.*\)\n{" } } */

--- a/testsuite/ipaclones/cms_kari.c.000i.ipa-clones
+++ b/testsuite/ipaclones/cms_kari.c.000i.ipa-clones
@@ -1,0 +1,16 @@
+Callgraph clone;cms_kek_cipher;1479;crypto/cms/cms_kari.c;186;12;cms_kek_cipher.isra.0;1527;crypto/cms/cms_kari.c;186;12;isra
+Callgraph clone;cms_kari_create_ephemeral_key;1481;crypto/cms/cms_kari.c;264;12;cms_kari_create_ephemeral_key.isra.1;1528;crypto/cms/cms_kari.c;264;12;isra
+Callgraph clone;cms_wrap_init;1483;crypto/cms/cms_kari.c;339;12;cms_wrap_init.isra.2;1529;crypto/cms/cms_kari.c;339;12;isra
+Callgraph clone;sk_CMS_RecipientEncryptedKey_push;1361;include/openssl/cms.h;34;1;cms_RecipientInfo_kari_init;1482;crypto/cms/cms_kari.c;294;5;inlining to
+Callgraph removal;sk_CMS_RecipientEncryptedKey_push;1361;include/openssl/cms.h;34;1
+Callgraph clone;sk_CMS_RecipientEncryptedKey_num;1351;include/openssl/cms.h;34;1;cms_RecipientInfo_kari_encrypt;1484;crypto/cms/cms_kari.c;373;5;inlining to
+Callgraph clone;sk_CMS_RecipientEncryptedKey_value;1352;include/openssl/cms.h;34;1;cms_RecipientInfo_kari_encrypt;1484;crypto/cms/cms_kari.c;373;5;inlining to
+Callgraph removal;sk_CMS_RecipientEncryptedKey_value;1352;include/openssl/cms.h;34;1
+Callgraph removal;sk_CMS_RecipientEncryptedKey_num;1351;include/openssl/cms.h;34;1
+Callgraph removal;cms_wrap_init;1483;crypto/cms/cms_kari.c;339;12
+Callgraph removal;cms_kari_create_ephemeral_key;1481;crypto/cms/cms_kari.c;264;12
+Callgraph removal;cms_kek_cipher;1479;crypto/cms/cms_kari.c;186;12
+Callgraph clone;cms_wrap_init.isra.2;1529;crypto/cms/cms_kari.c;339;12;cms_RecipientInfo_kari_encrypt;1484;crypto/cms/cms_kari.c;373;5;inlining to
+Callgraph clone;cms_kari_create_ephemeral_key.isra.1;1528;crypto/cms/cms_kari.c;264;12;cms_RecipientInfo_kari_init;1482;crypto/cms/cms_kari.c;294;5;inlining to
+Callgraph removal;cms_kari_create_ephemeral_key.isra.1;1528;crypto/cms/cms_kari.c;264;12
+Callgraph removal;cms_wrap_init.isra.2;1529;crypto/cms/cms_kari.c;339;12

--- a/testsuite/meson.build
+++ b/testsuite/meson.build
@@ -14,7 +14,7 @@
 # Author: Giuliano Belinassi
 
 runtest = find_program('lib/runtest.py')
-ordinary_test_dirs = [ 'small/', 'includes/', 'ccp/', 'decompress', 'linux', 'lateext' ]
+ordinary_test_dirs = [ 'small', 'includes', 'ccp', 'decompress', 'linux', 'lateext', 'ipaclones' ]
 
 returncode_to_bool = [ true, false ]
 

--- a/testsuite/small/closure-7.c
+++ b/testsuite/small/closure-7.c
@@ -1,0 +1,24 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=port_make_channel -DCE_NO_EXTERNALIZATION" }*/
+
+typedef struct ssl_st SSL;
+typedef union bio_addr_st BIO_ADDR;
+
+typedef struct quic_channel_st QUIC_CHANNEL;
+
+union bio_addr_st {
+  int a;
+};
+
+struct quic_channel_st {
+    SSL *tls;
+    BIO_ADDR cur_peer_addr;
+};
+
+QUIC_CHANNEL *port_make_channel(SSL *tls)
+{
+    QUIC_CHANNEL *ch;
+    ch->tls = tls;
+    return ch;
+}
+
+/* { dg-final { scan-tree-dump "union bio_addr_st {" } } */

--- a/testsuite/small/macro-23.c
+++ b/testsuite/small/macro-23.c
@@ -1,0 +1,103 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=f -DCE_EXPORT_SYMBOLS=OSSL_CMP_PROTECTEDPART_it" }*/
+/* { dg-xfail }*/
+
+# define DECLARE_ASN1_FUNCTIONS_attr(attr, type)                           \
+   DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_FUNCTIONS(type)                                      \
+   DECLARE_ASN1_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, name)                \
+   DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)                \
+   DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)
+
+# define DECLARE_ASN1_FUNCTIONS_attr(attr, type)                            \
+    DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_FUNCTIONS(type)                                       \
+    DECLARE_ASN1_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_attr(attr, type)                      \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, type)
+# define DECLARE_ASN1_ALLOC_FUNCTIONS(type)                                 \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_attr(extern, type)
+
+# define DECLARE_ASN1_FUNCTIONS_name_attr(attr, type, name)                 \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)                \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)
+# define DECLARE_ASN1_FUNCTIONS_name(type, name)                            \
+    DECLARE_ASN1_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_attr(attr, type, itname, name)       \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(attr, type, name)               \
+    DECLARE_ASN1_ITEM_attr(attr, itname)
+# define DECLARE_ASN1_ENCODE_FUNCTIONS(type, itname, name)                  \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_attr(extern, type, itname, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(attr, type, name)          \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_attr(attr, type, name, name)
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_name(type, name) \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(attr, type, name)          \
+    attr type *d2i_##name(type **a, const unsigned char **in, long len);    \
+    attr int i2d_##name(const type *a, unsigned char **out);
+# define DECLARE_ASN1_ENCODE_FUNCTIONS_only(type, name)                     \
+    DECLARE_ASN1_ENCODE_FUNCTIONS_only_attr(extern, type, name)
+
+# define DECLARE_ASN1_NDEF_FUNCTION_attr(attr, name)                        \
+    attr int i2d_##name##_NDEF(const name *a, unsigned char **out);
+# define DECLARE_ASN1_NDEF_FUNCTION(name)                                   \
+    DECLARE_ASN1_NDEF_FUNCTION_attr(extern, name)
+
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(attr, type, name)           \
+    attr type *name##_new(void);                                            \
+    attr void name##_free(type *a);
+# define DECLARE_ASN1_ALLOC_FUNCTIONS_name(type, name)                      \
+    DECLARE_ASN1_ALLOC_FUNCTIONS_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_DUP_FUNCTION_attr(attr, type)                         \
+    DECLARE_ASN1_DUP_FUNCTION_name_attr(attr, type, type)
+# define DECLARE_ASN1_DUP_FUNCTION(type)                                    \
+    DECLARE_ASN1_DUP_FUNCTION_attr(extern, type)
+
+# define DECLARE_ASN1_DUP_FUNCTION_name_attr(attr, type, name)              \
+    attr type *name##_dup(const type *a);
+# define DECLARE_ASN1_DUP_FUNCTION_name(type, name)                         \
+    DECLARE_ASN1_DUP_FUNCTION_name_attr(extern, type, name)
+
+# define DECLARE_ASN1_PRINT_FUNCTION_attr(attr, stname)                     \
+    DECLARE_ASN1_PRINT_FUNCTION_fname_attr(attr, stname, stname)
+# define DECLARE_ASN1_PRINT_FUNCTION(stname)                                \
+    DECLARE_ASN1_PRINT_FUNCTION_attr(extern, stname)
+
+# define DECLARE_ASN1_PRINT_FUNCTION_fname_attr(attr, stname, fname)        \
+    attr int fname##_print_ctx(BIO *out, const stname *x, int indent,       \
+                               const ASN1_PCTX *pctx);
+# define DECLARE_ASN1_PRINT_FUNCTION_fname(stname, fname)                   \
+    DECLARE_ASN1_PRINT_FUNCTION_fname_attr(extern, stname, fname)
+
+# define DECLARE_ASN1_ITEM_attr(attr, name)                                 \
+    attr const ASN1_ITEM * name##_it(void);
+# define DECLARE_ASN1_ITEM(name)                                            \
+    DECLARE_ASN1_ITEM_attr(extern, name)
+
+
+#define ASN1_ITEM_rptr(ref) (ref##_it())
+
+typedef struct asn_item ASN1_ITEM;
+
+typedef struct pkiheader OSSL_CMP_PKIHEADER;
+typedef struct pkibody   OSSL_CMP_PKIBODY;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+    OSSL_CMP_PKIBODY *body;
+} OSSL_CMP_PROTECTEDPART;
+
+DECLARE_ASN1_FUNCTIONS(OSSL_CMP_PROTECTEDPART);
+
+void *f(void)
+{
+  return (void *) ASN1_ITEM_rptr(OSSL_CMP_PROTECTEDPART);
+}
+
+/* { dg-final { scan-tree-dump "\(\*klpe_OSSL_CMP_PROTECTEDPART_it\)\(\)" } } */

--- a/testsuite/small/record-13.c
+++ b/testsuite/small/record-13.c
@@ -1,0 +1,25 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=ossl_cmp_calc_protection -DCE_NO_EXTERNALIZATION" }*/
+
+typedef struct ossl_cmp_pkiheader_st OSSL_CMP_PKIHEADER;
+typedef struct ossl_cmp_msg_st OSSL_CMP_MSG;
+
+struct ossl_cmp_msg_st {
+    OSSL_CMP_PKIHEADER *header;
+};
+
+
+typedef struct ossl_cmp_ctx_st OSSL_CMP_CTX;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+} OSSL_CMP_PROTECTEDPART;
+
+void *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
+                                          const OSSL_CMP_MSG *msg)
+{
+    OSSL_CMP_PROTECTEDPART prot_part;
+    prot_part.header = msg->header;
+    return ((void*)0);
+}
+
+/* { dg-final { scan-tree-dump "struct ossl_cmp_msg_st {\n *OSSL_CMP_PKIHEADER \*header;" } } */

--- a/testsuite/small/record-14.c
+++ b/testsuite/small/record-14.c
@@ -1,0 +1,26 @@
+/* { dg-options "-DCE_EXTRACT_FUNCTIONS=ossl_cmp_calc_protection -DCE_NO_EXTERNALIZATION" }*/
+
+typedef struct ossl_cmp_pkiheader_st OSSL_CMP_PKIHEADER;
+typedef struct ossl_cmp_msg_st OSSL_CMP_MSG;
+
+struct ossl_cmp_msg_st {
+    OSSL_CMP_PKIHEADER *header;
+};
+
+struct ossl_cmp_msg_st;
+
+typedef struct ossl_cmp_ctx_st OSSL_CMP_CTX;
+
+typedef struct ossl_cmp_protectedpart_st {
+    OSSL_CMP_PKIHEADER *header;
+} OSSL_CMP_PROTECTEDPART;
+
+void *ossl_cmp_calc_protection(const OSSL_CMP_CTX *ctx,
+                                          const OSSL_CMP_MSG *msg)
+{
+    OSSL_CMP_PROTECTEDPART prot_part;
+    prot_part.header = msg->header;
+    return ((void*)0);
+}
+
+/* { dg-final { scan-tree-dump "struct ossl_cmp_msg_st {\n *OSSL_CMP_PKIHEADER \*header;" } } */


### PR DESCRIPTION
    Merge update IPA clones callgraph with information from the source code.

    From openssl-1_1 we have:
    ```
    "cms_kek_cipher" -> "cms_kek_cipher.isra.0"
    ```
    and no information where cms_kek_cipher.isra.0 end up. This commit uses
    the information compiled in the source file to update the IPA clones
    callgraph into something more usable.  For that, we decide to merge the
    nodes created by GCC and update it with information that is only
    provided in the source code of the file, like the callers of
    cms_kek_cipher.isra.0.
